### PR TITLE
[FRD-82] Reading company name on experience

### DIFF
--- a/src/components/widgets/CompaniesWidget/CompaniesWidget.scss
+++ b/src/components/widgets/CompaniesWidget/CompaniesWidget.scss
@@ -1,0 +1,11 @@
+@use '@/style/variables' as *;
+
+.CompaniesWidget {
+   .MuiAvatar-circular {
+      background-color: $text;
+
+      img {
+         object-fit: contain;
+      }
+   }
+}

--- a/src/components/widgets/ExperiencesWidget/ExperiencesWidget.types.ts
+++ b/src/components/widgets/ExperiencesWidget/ExperiencesWidget.types.ts
@@ -1,3 +1,5 @@
+import WidgetCompany from "../CompaniesWidget/CompaniesWidget.types";
+
 export interface WidgetExperienceObject {
    id: string;
    title: string;
@@ -6,4 +8,5 @@ export interface WidgetExperienceObject {
    start_date: string;
    end_date: string;
    summary: string;
+   company?: WidgetCompany
 }

--- a/src/components/widgets/ExperiencesWidget/experienceWidget.config.tsx
+++ b/src/components/widgets/ExperiencesWidget/experienceWidget.config.tsx
@@ -6,12 +6,12 @@ export const experienceWidgetColumns: IColumnConfig[] = [
       propKey: 'title',
       label: 'Title',
       align: 'left',
-      format: (value: unknown, item: unknown) => {
+      format: (_: unknown, item: unknown) => {
          const row = item as WidgetExperienceObject;
 
          return (
             <>
-               <strong>{String(value)}</strong>
+               <strong>{String(row.company?.company_name || row.title)}</strong>
                <br />
                <span>{row.position}</span>
             </>

--- a/src/style/style.scss
+++ b/src/style/style.scss
@@ -54,3 +54,4 @@
 
 // Widgets
 @use '@/components/widgets/SkillsWidget/SkillsWidget';
+@use '@/components/widgets/CompaniesWidget/CompaniesWidget';


### PR DESCRIPTION
## [FRD-82] Description
This pull request introduces enhancements to the `CompaniesWidget` and `ExperiencesWidget` components, focusing on styling, data integration, and display logic. Key changes include adding SCSS for the `CompaniesWidget`, updating the `ExperiencesWidget` to reference company data, and modifying the display format for experience titles.

### Styling Improvements:
* [`src/components/widgets/CompaniesWidget/CompaniesWidget.scss`](diffhunk://#diff-bd68c145e1c0b1f53d075a662737ac6667cdfe3fc9d68fa657fc9ad143894c72R1-R11): Added SCSS for the `CompaniesWidget`, including styles for `MuiAvatar-circular` to set `background-color` and ensure images use `object-fit: contain`.
* [`src/style/style.scss`](diffhunk://#diff-b8ebd6839f7c23de5a6c242d8f7ac77a1f6122ae5e3f045515ded4dd990ab32dR57): Imported the `CompaniesWidget` styles into the global stylesheet.

### Data Integration:
* [`src/components/widgets/ExperiencesWidget/ExperiencesWidget.types.ts`](diffhunk://#diff-8c4a78763c097ea82ee6e10d2a13a65f0205bd1275e7b14331687fbabf86cc21R1-R2): Introduced an optional `company` field in the `WidgetExperienceObject` interface, referencing the `WidgetCompany` type from `CompaniesWidget.types`. [[1]](diffhunk://#diff-8c4a78763c097ea82ee6e10d2a13a65f0205bd1275e7b14331687fbabf86cc21R1-R2) [[2]](diffhunk://#diff-8c4a78763c097ea82ee6e10d2a13a65f0205bd1275e7b14331687fbabf86cc21R11)

### Display Logic:
* [`src/components/widgets/ExperiencesWidget/experienceWidget.config.tsx`](diffhunk://#diff-10dbaba6c58c9f2ea1a37f709aefbb81f4532c6546c78878268574802f00fcddL9-R14): Updated the `format` function for experience titles to display the company name (if available) or fallback to the title.