### PR TITLE
[FRD-83] Dynamic options load

### DIFF
--- a/src/hooks/Form/Form.types.ts
+++ b/src/hooks/Form/Form.types.ts
@@ -56,7 +56,9 @@ export interface FormInputProps extends FormBaseInputProps {
 }
 
 export interface FormSelectProps extends FormBaseInputProps {
-  options: Array<FormSelectOption>;
+  disableNone?: boolean;
+  loadOptions?: () => Promise<Array<FormSelectOption>>;
+  options?: Array<FormSelectOption>;
 }
 
 export interface FormSelectOption {

--- a/src/hooks/Form/inputs/FormSelect.tsx
+++ b/src/hooks/Form/inputs/FormSelect.tsx
@@ -1,12 +1,28 @@
 import { FormControl, InputLabel, MenuItem, Select } from '@mui/material';
 import { useForm } from '../Form';
 import { FormSelectProps } from '../Form.types';
+import { useEffect, useRef, useState } from 'react';
 
-export default function FormSelect({ id, fieldName, label, options, onChange = () => {}, ...props }: FormSelectProps): React.ReactElement {
+export default function FormSelect({
+   id, fieldName, label, disableNone = false, options = [], loadOptions, onChange = () => {}, ...props
+}: FormSelectProps): React.ReactElement {
    const { getValue, setFieldValue } = useForm();
+   const [ opts, setOpts ] = useState(options);
+   const isLoaded = useRef<boolean>(false);
 
    const idPrefix = id || fieldName;
    const labelId = `${idPrefix}-label`;
+
+   useEffect(() => {
+      if (isLoaded.current || typeof loadOptions !== 'function' || !fieldName) return;
+
+      isLoaded.current = true;
+      loadOptions().then((loadedOptions) => {
+         setOpts(loadedOptions);
+      }).catch((error) => {
+         console.error('Failed to load options:', error);
+      });
+   }, [ loadOptions, fieldName ]);
 
    if (!fieldName) {
       console.warn('FormSelect requires a fieldName prop to function correctly.');
@@ -29,11 +45,11 @@ export default function FormSelect({ id, fieldName, label, options, onChange = (
             value={getValue(fieldName) || ''}
             onChange={handleChange}
          >
-            <MenuItem value="">
+            <MenuItem value="" disabled={disableNone}>
                <em>None</em>
             </MenuItem>
 
-            {options.map((option) => (
+            {opts.map((option) => (
                <MenuItem key={option.value} value={option.value}>
                   {option.label}
                </MenuItem>

--- a/src/services/Ajax/Ajax.ts
+++ b/src/services/Ajax/Ajax.ts
@@ -73,6 +73,7 @@ export default class Ajax {
                const errorData = errorResponse?.data as AjaxResponseError;
 
                return {
+                  data: errorData,
                   status: axiosError.response?.status || 0,
                   statusText: axiosError.response?.statusText || 'Network Error',
                   headers: axiosError.response?.headers || {},

--- a/src/services/Ajax/Ajax.types.ts
+++ b/src/services/Ajax/Ajax.types.ts
@@ -22,6 +22,7 @@ export interface AjaxResponse<T = unknown> {
 }
 
 export interface AjaxResponseError {
+   data: unknown;
    status: number;
    statusText: string;
    code?: string;


### PR DESCRIPTION
## [FRD-83] Description
This pull request introduces enhancements to the `FormSelect` component to support dynamic option loading and additional configuration, as well as an update to the `Ajax` service to include error response data. Below are the key changes grouped by theme:

### Enhancements to `FormSelect` Component
* Updated `FormSelectProps` in `src/hooks/Form/Form.types.ts` to add new optional properties: `disableNone`, `loadOptions`, and `options`, enabling dynamic loading and customization of options.
* Modified the `FormSelect` component in `src/hooks/Form/inputs/FormSelect.tsx` to:
  - Add state management for options using `useState` and `useEffect` to handle dynamic loading via the `loadOptions` callback.
  - Add support for disabling the "None" option when `disableNone` is set to `true`.

### Updates to `Ajax` Service
* Enhanced the `Ajax` class in `src/services/Ajax/Ajax.ts` to include the `data` field from error responses in the returned error object.
* Updated the `AjaxResponseError` interface in `src/services/Ajax/Ajax.types.ts` to include a `data` property for storing additional error details.