### PR TITLE
[FRD-88] Edit Experience Details

### DIFF
--- a/src/components/content/admin/experience/ExperienceDetailsContent/ExperienceDetailsContent.module.scss
+++ b/src/components/content/admin/experience/ExperienceDetailsContent/ExperienceDetailsContent.module.scss
@@ -1,10 +1,6 @@
 @use '@/style/variables' as *;
 
 .ExperienceDetailsContent {
-   h2 {
-      margin-bottom: 2rem;
-   }
-
    .field-wrap {
       width: 100%;
       display: flex;
@@ -35,5 +31,17 @@
 
    .languageSet {
       margin-top: 1rem;
+   }
+
+   .cardHeader {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 2rem;
+
+      .editButton {
+         background-color: $primary;
+         color: $text;
+      }
    }
 }

--- a/src/components/content/admin/experience/ExperienceDetailsContent/common/ExperienceDetailsFieldWrap.tsx
+++ b/src/components/content/admin/experience/ExperienceDetailsContent/common/ExperienceDetailsFieldWrap.tsx
@@ -2,6 +2,6 @@ import { parseCSS } from '@/utils/parse';
 import styleModule from '../ExperienceDetailsContent.module.scss';
 
 export default function ExperienceDetailsFieldWrap({ vertical, children }: { vertical?: boolean; children: React.ReactNode }) {
-   const CSS = parseCSS(vertical ? styleModule.vertical : 'horizontal', styleModule['field-wrap']);
+   const CSS = parseCSS(vertical ? styleModule.vertical : '', styleModule['field-wrap']);
    return <div className={CSS}>{children}</div>;
 }

--- a/src/components/content/admin/experience/ExperienceDetailsContent/common/ExperienceDetailsSection.tsx
+++ b/src/components/content/admin/experience/ExperienceDetailsContent/common/ExperienceDetailsSection.tsx
@@ -1,30 +1,56 @@
 import { Card } from '@/components/common';
 import { useExperienceDetails } from '../ExperienceDetailsContext';
 import FieldWrap from './ExperienceDetailsFieldWrap';
+import classNames from '../ExperienceDetailsContent.module.scss';
+import { IconButton } from '@mui/material';
+import { Edit as EditIcon } from '@mui/icons-material';
+import { Fragment, useState } from 'react';
+import EditExperienceDetails from '@/components/forms/EditExperienceDetails/EditExperienceDetails';
 
 export default function ExperienceDetailsSection() {
    const experience = useExperienceDetails();
+   const [editMode, setEditMode] = useState<boolean>(false);
 
    return (
       <Card padding="l">
-         <h2>Experience Details</h2>
+         <div className={classNames.cardHeader}>
+            <h2>Experience Details</h2>
 
-         <FieldWrap>
-            <label>Company:</label>
-            <p>{experience.company?.company_name}</p>
-         </FieldWrap>
-         <FieldWrap>
-            <label>Type:</label>
-            <p>{experience.type}</p>
-         </FieldWrap>
-         <FieldWrap>
-            <label>Start Date:</label>
-            <p>{new Date(experience.start_date).toLocaleDateString()}</p>
-         </FieldWrap>
-         <FieldWrap>
-            <label>End Date:</label>
-            <p>{new Date(experience.end_date).toLocaleDateString()}</p>
-         </FieldWrap>
+            {!editMode && (
+               <IconButton className={classNames.editButton} onClick={() => setEditMode(true)} aria-label="Edit Experience">
+                  <EditIcon />
+               </IconButton>
+            )}
+         </div>
+
+         {editMode && <EditExperienceDetails />}
+
+         {!editMode && (
+            <FieldWrap>
+               <label>Title:</label>
+               <p>{experience.title}</p>
+            </FieldWrap>
+         )}
+         {!editMode && (
+            <Fragment>
+               <FieldWrap>
+                  <label>Company:</label>
+                  <p>{experience.company?.company_name}</p>
+               </FieldWrap>
+               <FieldWrap>
+                  <label>Type:</label>
+                  <p>{experience.type}</p>
+               </FieldWrap>
+               <FieldWrap>
+                  <label>Start Date:</label>
+                  <p>{new Date(experience.start_date).toLocaleDateString()}</p>
+               </FieldWrap>
+               <FieldWrap>
+                  <label>End Date:</label>
+                  <p>{new Date(experience.end_date).toLocaleDateString()}</p>
+               </FieldWrap>
+            </Fragment>
+         )}
       </Card>
    );
 }

--- a/src/components/content/admin/experience/ExperienceDetailsContent/common/ExperienceDetailsSidebar.tsx
+++ b/src/components/content/admin/experience/ExperienceDetailsContent/common/ExperienceDetailsSidebar.tsx
@@ -1,14 +1,21 @@
 import Card from '@/components/common/Card/Card';
-import { Fragment }  from 'react';
+import { Fragment, useState } from 'react';
 import FieldWrap from './ExperienceDetailsFieldWrap';
 import { SkillBadge } from '@/components/badges';
 import { useExperienceDetails } from '../ExperienceDetailsContext';
+import { IconButton } from '@mui/material';
+import { Edit } from '@mui/icons-material';
+import classNames from '../ExperienceDetailsContent.module.scss'
+import EditExperienceStatus from '@/components/forms/EditExperienceStatus/EditExperienceStatus';
+import EditExperienceSkills from '@/components/forms/EditExperienceSkills/EditExperienceSkills';
 
 function SectionCard({ children }: { children: React.ReactNode }) {
    return <Card padding="l">{children}</Card>;
 }
 
 export default function ExperienceDetailsSidebar(): React.ReactElement {
+   const [editStatus, setEditStatus] = useState<boolean>(false);
+   const [editSkills, setEditSkills] = useState<boolean>(false);
    const experience = useExperienceDetails();
 
    return (
@@ -18,24 +25,33 @@ export default function ExperienceDetailsSidebar(): React.ReactElement {
                <label>ID:</label>
                <p>{experience.id}</p>
             </FieldWrap>
-            <FieldWrap>
-               <label>Status:</label>
-               <p>{experience.status}</p>
-            </FieldWrap>
+
+            <EditExperienceStatus />
          </SectionCard>
 
          <SectionCard>
-            <h2>Skills</h2>
+            <div className={classNames.cardHeader}>
+               <h2>Skills</h2>
 
-            <FieldWrap>
-               {experience.skills.length > 0 ? (
-                  experience.skills.map((skill) => (
-                     <SkillBadge key={skill.skill_id} value={skill.name} />
-                  ))
-               ) : (
-                  <p>No skills associated with this experience.</p>
+               {!editSkills && (
+                  <IconButton className={classNames.editButton} onClick={() => setEditSkills(true)} aria-label="Edit Skills">
+                     <Edit />
+                  </IconButton>
                )}
-            </FieldWrap>
+            </div>
+
+            {editSkills && <EditExperienceSkills />}
+            {!editSkills && (
+               <FieldWrap>
+                  {experience.skills.length > 0 ? (
+                     experience.skills.map((skill) => (
+                        <SkillBadge key={skill.skill_id} value={skill.name} />
+                     ))
+                  ) : (
+                     <p>No skills associated with this experience.</p>
+                  )}
+               </FieldWrap>
+            )}
          </SectionCard>
       </Fragment>
    );

--- a/src/components/forms/EditExperienceDetails/EditExperienceDetails.tsx
+++ b/src/components/forms/EditExperienceDetails/EditExperienceDetails.tsx
@@ -1,0 +1,28 @@
+import { Form, FormInput } from "@/hooks";
+import FormButtonSelect from "@/hooks/Form/inputs/FormButtonSelect";
+import FormDatePicker from "@/hooks/Form/inputs/FormDatePicker";
+import { handleExperienceLoadOptions, typeOptions } from "../CreateExperienceForm/CreateExperienceForm.config";
+import FormSelect from "@/hooks/Form/inputs/FormSelect";
+import { useAjax } from "@/hooks/useAjax";
+import { useTextResources } from "@/services/TextResources/TextResourcesProvider";
+import { useExperienceDetails } from "@/components/content/admin/experience/ExperienceDetailsContent/ExperienceDetailsContext";
+import { ExperienceData } from "@/types/database.types";
+import { handleExperienceUpdate } from "@/helpers/database.helpers";
+
+export default function EditExperienceDetails() {
+   const ajax = useAjax();
+   const { textResources } = useTextResources();
+   const experience = useExperienceDetails();
+
+   const handleSubmit = async (values: Partial<ExperienceData>) => await handleExperienceUpdate(ajax, experience, values);
+
+   return (
+      <Form initialValues={{ ...experience }} submitLabel="Save" onSubmit={handleSubmit} editMode>
+         <FormInput fieldName="title" label="Title" />
+         <FormSelect fieldName="company_id" label="Company" loadOptions={() => handleExperienceLoadOptions(ajax, textResources)} />
+         <FormButtonSelect fieldName="type" label="Type" options={typeOptions} />
+         <FormDatePicker fieldName="start_date" label="Start Date" />
+         <FormDatePicker fieldName="end_date" label="End Date" />
+      </Form>
+   );
+}

--- a/src/components/forms/EditExperienceSkills/EditExperienceSkills.tsx
+++ b/src/components/forms/EditExperienceSkills/EditExperienceSkills.tsx
@@ -1,0 +1,22 @@
+import { useExperienceDetails } from "@/components/content/admin/experience/ExperienceDetailsContent/ExperienceDetailsContext";
+import { Form } from "@/hooks";
+import FormMultiSelectChip from "@/hooks/Form/inputs/FormMultiSelectChip";
+import { handleSkillsLoadOptions } from "../CreateExperienceForm/CreateExperienceForm.config";
+import { useAjax } from "@/hooks/useAjax";
+import { useTextResources } from "@/services/TextResources/TextResourcesProvider";
+import { ExperienceData } from "@/types/database.types";
+import { handleExperienceUpdate } from "@/helpers/database.helpers";
+
+export default function EditExperienceSkills() {
+   const experience = useExperienceDetails();
+   const ajax = useAjax();
+   const { textResources } = useTextResources();
+
+   const handleSubmit = async (values: Partial<ExperienceData>) => await handleExperienceUpdate(ajax, experience, values);
+
+   return (
+      <Form initialValues={{ skills: experience.skills.map(skill => skill.id) }} submitLabel="Save Skills" onSubmit={handleSubmit} editMode>
+         <FormMultiSelectChip fieldName="skills" loadOptions={() => handleSkillsLoadOptions(ajax, textResources)} />
+      </Form>
+   );
+}

--- a/src/components/forms/EditExperienceStatus/EditExperienceStatus.tsx
+++ b/src/components/forms/EditExperienceStatus/EditExperienceStatus.tsx
@@ -1,0 +1,23 @@
+import { Form } from "@/hooks";
+import { statusOptions } from "../CreateExperienceForm/CreateExperienceForm.config";
+import FormButtonSelect from "@/hooks/Form/inputs/FormButtonSelect";
+import { useExperienceDetails } from "@/components/content/admin/experience/ExperienceDetailsContent/ExperienceDetailsContext";
+import { ExperienceData } from "@/types/database.types";
+import { handleExperienceUpdate } from "@/helpers/database.helpers";
+import { useAjax } from "@/hooks/useAjax";
+import { useRef } from "react";
+
+export default function EditExperienceStatus() {
+   const experience = useExperienceDetails();
+   const ajax = useAjax();
+
+   const handleSubmit = async (values: Partial<ExperienceData>) => {
+      return await handleExperienceUpdate(ajax, experience, values);
+   };
+
+   return (
+      <Form initialValues={{ status: experience.status }} onSubmit={handleSubmit} submitLabel="Save Status" editMode>
+         <FormButtonSelect fieldName="status" options={statusOptions} />
+      </Form>
+   );
+}

--- a/src/helpers/database.helpers.ts
+++ b/src/helpers/database.helpers.ts
@@ -1,0 +1,25 @@
+import Ajax from "@/services/Ajax/Ajax";
+import { ExperienceData } from "@/types/database.types";
+
+export const handleExperienceUpdate = async (ajax: Ajax, experience: ExperienceData, values: Partial<ExperienceData>) => {
+   if (!values || !Object.keys(values).length) {
+      console.warn('No valid updates provided. The "updates" param is empty.');
+      return { success: true };
+   }
+
+   try {
+      const updated = await ajax.post<ExperienceData>('/experience/update', {
+         experienceId: experience.id,
+         updates: values,
+      });
+
+      if (!updated.success) {
+         throw updated;
+      }
+
+      window.location.reload();
+      return { success: true };
+   } catch (error) {
+      throw error;
+   }
+};

--- a/src/hooks/Form/Form.types.ts
+++ b/src/hooks/Form/Form.types.ts
@@ -17,7 +17,9 @@ export interface FormResponseError {
 
 export interface FormContextType {
   values: FormValues;
+  updateData: FormValues;
   errors: FormErrors;
+  editMode: boolean;
   responseError: { message?: string } | null;
   getValue: (field: string) => unknown;
   setFieldValue: (field: string, value: unknown) => void;
@@ -27,11 +29,13 @@ export interface FormContextType {
 }
 
 export interface FormProviderProps {
+  ref?: React.RefObject<HTMLFormElement | null>;
   className?: string;
   children: React.ReactNode;
   hideSubmit?: boolean;
   submitLabel?: string;
   initialValues?: FormValues;
+  editMode?: boolean;
   onSubmit?: (values: FormValues, errors: FormErrors, event: FormEvent<HTMLFormElement>) => Promise<unknown> | unknown;
 }
 
@@ -71,6 +75,7 @@ export interface FormButtonSelectProps extends FormBaseInputProps {
   className?: string | string[];
   defaultValue?: string;
   options: Array<FormSelectOption>;
+  onSelect?: (values: FormValues) => void;
 }
 
 export interface FormDatePickerProps extends FormBaseInputProps {

--- a/src/hooks/Form/inputs/FormButtonSelect.tsx
+++ b/src/hooks/Form/inputs/FormButtonSelect.tsx
@@ -3,8 +3,8 @@ import { FormButtonSelectProps } from '../Form.types';
 import { useForm } from '../Form';
 import { parseCSS } from '@/utils/parse';
 
-export default function FormButtonSelect({ className, label, fieldName, options }: FormButtonSelectProps): React.ReactElement {
-   const { getValue, setFieldValue } = useForm();
+export default function FormButtonSelect({ className, label, fieldName, options, onSelect = () => {}}: FormButtonSelectProps): React.ReactElement {
+   const { getValue, setFieldValue, values, updateData, editMode } = useForm();
    const CSS = parseCSS(className, 'FormButtonSelect');
 
    if (!fieldName) {
@@ -14,7 +14,10 @@ export default function FormButtonSelect({ className, label, fieldName, options 
 
    const currentValue = getValue(fieldName);
    const isSelected = (value: string) => (currentValue === value) ? 'selected' : '';
-   const handleChange = (value: string) => setFieldValue(fieldName, value);
+   const handleChange = (value: string) => {
+      onSelect(editMode ? updateData : values);
+      setFieldValue(fieldName, value);
+   };
 
    return (
       <div className={CSS}>


### PR DESCRIPTION
## [FRD-88] Description
This pull request introduces enhancements to the admin experience management interface, focusing on enabling edit functionality for experience details, skills, and status. It also refactors the form handling logic to support partial updates in edit mode. Below are the key changes grouped by theme:

### UI Enhancements for Editing Experience Details
* Added an edit button and modal for editing experience details (`EditExperienceDetails`) in `ExperienceDetailsSection`. The modal includes fields for title, company, type, start date, and end date. [[1]](diffhunk://#diff-7dbb18dcde92e042818fedd57548c3d7ae331857b848c53be2d16eb4440d6019R4-R35) [[2]](diffhunk://#diff-20fe5af41ef42d1c0ed0d51dff4d730e9fdcec318f4098b93a1174cbc06ad972R1-R28)
* Introduced a similar edit button and modal for managing skills (`EditExperienceSkills`) and status (`EditExperienceStatus`) in `ExperienceDetailsSidebar`. [[1]](diffhunk://#diff-c84dab5bd9308950a88f1316cbf6054849a96c841e889294628e53fdc4ef6aa5L2-R18) [[2]](diffhunk://#diff-c84dab5bd9308950a88f1316cbf6054849a96c841e889294628e53fdc4ef6aa5L21-R44) [[3]](diffhunk://#diff-c2c0feef2d0005aeb531b3b1cd216e8c132139c429ca7004df020e6598b94648R1-R22) [[4]](diffhunk://#diff-124441732a0b9206604c6f18783b49a5c0f989ed973ca74b026f2ca4b2502843R1-R23)

### Styling Updates
* Added a `.cardHeader` class with flexbox styling for aligning headers and buttons in `ExperienceDetailsContent.module.scss`.
* Removed unused `h2` styling, streamlining the CSS file.

### Form Logic Refactor
* Updated the `Form` component to support `editMode`, allowing partial updates by maintaining a separate `updateData` state for modified fields. [[1]](diffhunk://#diff-ad2bdc4c9a392b72df135f2f1a2245e88c9edcaffd493a03cc0800cb63e094bdR12-R16) [[2]](diffhunk://#diff-ad2bdc4c9a392b72df135f2f1a2245e88c9edcaffd493a03cc0800cb63e094bdR26-R37) [[3]](diffhunk://#diff-ad2bdc4c9a392b72df135f2f1a2245e88c9edcaffd493a03cc0800cb63e094bdL48-R55)
* Modified `FormButtonSelect` to invoke an `onSelect` callback with the appropriate data (`updateData` or `values`) based on `editMode`. [[1]](diffhunk://#diff-a4597b27f779b54198a2aded4da3754b6cf2041405328eab1d33db0d2d03a234L6-R7) [[2]](diffhunk://#diff-a4597b27f779b54198a2aded4da3754b6cf2041405328eab1d33db0d2d03a234L17-R20)

### Backend Integration
* Added a helper function, `handleExperienceUpdate`, to handle AJAX requests for updating experience details, skills, and status via the `/experience/update` endpoint.

### Type and Interface Updates
* Extended form-related types (`FormContextType`, `FormProviderProps`, etc.) to include `editMode` and `updateData` for better type safety and functionality. [[1]](diffhunk://#diff-679a4ffc1b4010d87989ea7177fd7a529b076edc2be479632a44e17ed7d55f34R20-R22) [[2]](diffhunk://#diff-679a4ffc1b4010d87989ea7177fd7a529b076edc2be479632a44e17ed7d55f34R32-R38) [[3]](diffhunk://#diff-679a4ffc1b4010d87989ea7177fd7a529b076edc2be479632a44e17ed7d55f34R78)