### PR TITLE
[FRD-89] Edit Experience Status and Type

### DIFF
--- a/src/components/forms/CreateExperienceForm/CreateExperienceForm.config.ts
+++ b/src/components/forms/CreateExperienceForm/CreateExperienceForm.config.ts
@@ -72,6 +72,6 @@ export const typeOptions = [
 
 export const statusOptions = [
    { value: 'draft', label: 'Draft' },
-   { value: 'publish', label: 'Publish' }
+   { value: 'published', label: 'Published' }
 ];
 

--- a/src/components/forms/EditExperienceStatus/EditExperienceStatus.tsx
+++ b/src/components/forms/EditExperienceStatus/EditExperienceStatus.tsx
@@ -19,7 +19,7 @@ export default function EditExperienceStatus() {
    };
 
    return (
-      <Form initialValues={{ status: experience.status }} submitLabel="Save Status" hideSubmit editMode>
+      <Form initialValues={{ status: experience.status }} hideSubmit editMode>
          <FormButtonSelect fieldName="status" options={statusOptions} onSelect={handleSelect} />
       </Form>
    );

--- a/src/components/forms/EditExperienceStatus/EditExperienceStatus.tsx
+++ b/src/components/forms/EditExperienceStatus/EditExperienceStatus.tsx
@@ -14,9 +14,13 @@ export default function EditExperienceStatus() {
       return await handleExperienceUpdate(ajax, experience, values);
    };
 
+   const handleSelect = (value: string) => {
+      handleSubmit({ status: value });
+   };
+
    return (
-      <Form initialValues={{ status: experience.status }} onSubmit={handleSubmit} submitLabel="Save Status" editMode>
-         <FormButtonSelect fieldName="status" options={statusOptions} />
+      <Form initialValues={{ status: experience.status }} submitLabel="Save Status" hideSubmit editMode>
+         <FormButtonSelect fieldName="status" options={statusOptions} onSelect={handleSelect} />
       </Form>
    );
 }

--- a/src/hooks/Form/Form.types.ts
+++ b/src/hooks/Form/Form.types.ts
@@ -75,7 +75,7 @@ export interface FormButtonSelectProps extends FormBaseInputProps {
   className?: string | string[];
   defaultValue?: string;
   options: Array<FormSelectOption>;
-  onSelect?: (values: FormValues) => void;
+  onSelect?: (value: string) => void;
 }
 
 export interface FormDatePickerProps extends FormBaseInputProps {

--- a/src/hooks/Form/inputs/FormButtonSelect.tsx
+++ b/src/hooks/Form/inputs/FormButtonSelect.tsx
@@ -4,7 +4,7 @@ import { useForm } from '../Form';
 import { parseCSS } from '@/utils/parse';
 
 export default function FormButtonSelect({ className, label, fieldName, options, onSelect = () => {}}: FormButtonSelectProps): React.ReactElement {
-   const { getValue, setFieldValue, values, updateData, editMode } = useForm();
+   const { getValue, setFieldValue } = useForm();
    const CSS = parseCSS(className, 'FormButtonSelect');
 
    if (!fieldName) {

--- a/src/hooks/Form/inputs/FormButtonSelect.tsx
+++ b/src/hooks/Form/inputs/FormButtonSelect.tsx
@@ -16,10 +16,7 @@ export default function FormButtonSelect({ className, label, fieldName, options,
    const isSelected = (value: string) => (currentValue === value) ? 'selected' : '';
    const handleChange = (value: string) => {
       setFieldValue(fieldName, value);
-
-      setTimeout(() => {
-         onSelect(editMode ? updateData : values);
-      }, 0);
+      onSelect(value);
    };
 
    return (


### PR DESCRIPTION
## [FRD-89] Description
This pull request focuses on improving the handling of the `onSelect` functionality in the `FormButtonSelect` component and updating the status options for experiences. The most important changes include modifying the `onSelect` callback to simplify its parameters, updating the `statusOptions` values, and adjusting related components to accommodate these changes.

### Updates to `onSelect` functionality:

* [`src/hooks/Form/Form.types.ts`](diffhunk://#diff-679a4ffc1b4010d87989ea7177fd7a529b076edc2be479632a44e17ed7d55f34L78-R78): Updated the `onSelect` property in the `FormButtonSelectProps` interface to accept a single `string` value instead of an object of `FormValues`.
* [`src/hooks/Form/inputs/FormButtonSelect.tsx`](diffhunk://#diff-a4597b27f779b54198a2aded4da3754b6cf2041405328eab1d33db0d2d03a234L19-R19): Simplified the `handleChange` function to directly call `onSelect` with the selected value, removing the timeout logic and unnecessary parameter handling.

### Updates to experience status handling:

* [`src/components/forms/CreateExperienceForm/CreateExperienceForm.config.ts`](diffhunk://#diff-8641b036c91d4b41588cb0f01fdf86bd0d3efaacb851dc9c0f9b1e939da58a03L75-R75): Renamed the `statusOptions` value `publish` to `published` for consistency.
* [`src/components/forms/EditExperienceStatus/EditExperienceStatus.tsx`](diffhunk://#diff-124441732a0b9206604c6f18783b49a5c0f989ed973ca74b026f2ca4b2502843R17-R23): Added a new `handleSelect` function to handle status updates directly and passed it to the `FormButtonSelect` component via the `onSelect` prop. Adjusted the `Form` component to hide the submit button since the selection now triggers updates automatically.

[FRD-89]: https://feliperamosdev.atlassian.net/browse/FRD-89?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ