### PR TITLE
[FRD-90] Edit Experience Languages Set

### DIFF
--- a/src/components/content/admin/experience/ExperienceDetailsContent/common/ExperienceSetsSection.tsx
+++ b/src/components/content/admin/experience/ExperienceDetailsContent/common/ExperienceSetsSection.tsx
@@ -1,53 +1,73 @@
-import { Card } from "@/components/common";
-import TabsContent from "@/components/layout/TabsContent/TabsContent";
-import { TabOption } from "@/components/layout/TabsContent/TabsContent.types";
-import { useExperienceDetails } from "../ExperienceDetailsContext";
+import { Card } from '@/components/common';
+import TabsContent from '@/components/layout/TabsContent/TabsContent';
+import { TabOption } from '@/components/layout/TabsContent/TabsContent.types';
+import { useExperienceDetails } from '../ExperienceDetailsContext';
 import styleModule from '../ExperienceDetailsContent.module.scss';
-import FieldWrap from "./ExperienceDetailsFieldWrap";
+import FieldWrap from './ExperienceDetailsFieldWrap';
+import classNames from '../ExperienceDetailsContent.module.scss';
+import { useState } from 'react';
+import { IconButton } from '@mui/material';
+import { Edit } from '@mui/icons-material';
+import EditExperienceSetForm from '@/components/forms/EditExperienceSetForm/EditExperienceSetForm';
 
 export default function ExperienceSetsSection(): React.ReactElement {
    const experience = useExperienceDetails();
+   const [editMode, setEditMode] = useState<boolean>(false);
+
    const tabOptions: TabOption[] = [
       { label: 'English (Default)', value: 'en' }
    ];
 
    return (
       <Card padding="l">
-         <TabsContent options={tabOptions}>
-            {tabOptions.map((option: TabOption) => {
-               const languageSet = experience.languageSets.find(set => set.language_set === option.value);
+         <div className={classNames.cardHeader}>
+            <h2>Language Sets</h2>
 
-               if (!languageSet) {
-                  return null;
-               }
+            {!editMode && (
+               <IconButton className={classNames.editButton} onClick={() => setEditMode(true)} aria-label="Edit Experience">
+                  <Edit />
+               </IconButton>
+            )}
+         </div>
 
-               return (
-                  <div className={styleModule.languageSet} key={option.value}>
-                     <FieldWrap>
-                        <label>Position:</label>
-                        <p>{languageSet.position || 'No position available.'}</p>
-                     </FieldWrap>
-                     <FieldWrap>
-                        <label>Slug:</label>
-                        <p>{languageSet.slug || 'No slug available.'}</p>
-                     </FieldWrap>
+         {editMode && <EditExperienceSetForm />}
+         {!editMode && (
+            <TabsContent options={tabOptions}>
+               {tabOptions.map((option: TabOption) => {
+                  const languageSet = experience.languageSets.find(set => set.language_set === option.value);
 
-                     <FieldWrap vertical>
-                        <label>Summary:</label>
-                        <p>{languageSet.summary || 'No summary available.'}</p>
-                     </FieldWrap>
-                     <FieldWrap vertical>
-                        <label>Description:</label>
-                        <p>{languageSet.description || 'No description available.'}</p>
-                     </FieldWrap>
-                     <FieldWrap vertical>
-                        <label>Responsibilities:</label>
-                        <p>{languageSet.responsibilities || 'No responsibilities available.'}</p>
-                     </FieldWrap>
-                  </div>
-               );
-            })}
-         </TabsContent>
+                  if (!languageSet) {
+                     return null;
+                  }
+
+                  return (
+                     <div className={styleModule.languageSet} key={option.value}>
+                        <FieldWrap>
+                           <label>Position:</label>
+                           <p>{languageSet.position || 'No position available.'}</p>
+                        </FieldWrap>
+                        <FieldWrap>
+                           <label>Slug:</label>
+                           <p>{languageSet.slug || 'No slug available.'}</p>
+                        </FieldWrap>
+
+                        <FieldWrap vertical>
+                           <label>Summary:</label>
+                           <p>{languageSet.summary || 'No summary available.'}</p>
+                        </FieldWrap>
+                        <FieldWrap vertical>
+                           <label>Description:</label>
+                           <p>{languageSet.description || 'No description available.'}</p>
+                        </FieldWrap>
+                        <FieldWrap vertical>
+                           <label>Responsibilities:</label>
+                           <p>{languageSet.responsibilities || 'No responsibilities available.'}</p>
+                        </FieldWrap>
+                     </div>
+                  );
+               })}
+            </TabsContent>
+         )}
       </Card>
    );
 }

--- a/src/components/forms/EditExperienceSetForm/EditExperienceSetForm.tsx
+++ b/src/components/forms/EditExperienceSetForm/EditExperienceSetForm.tsx
@@ -1,0 +1,41 @@
+import { useExperienceDetails } from '@/components/content/admin/experience/ExperienceDetailsContent/ExperienceDetailsContext';
+import { Form, FormInput } from '@/hooks';
+import { ExperienceSetData } from '@/types/database.types';
+import { EditExperienceSetFormProps } from './EditExperienceSetForm.types';
+import { useAjax } from '@/hooks/useAjax';
+
+export default function EditExperienceSetForm({ language_set = 'en' }: EditExperienceSetFormProps): React.ReactElement {
+   const ajax = useAjax();
+   const experience = useExperienceDetails();
+   const languageSet = experience.languageSets.find((set: ExperienceSetData) => set.language_set === language_set);
+
+   const handleSubmit = async (values: Partial<ExperienceSetData>) => {
+      if (!languageSet) {
+         throw new Error('Language set not found');
+      }
+
+      try {
+         const updatedSet = await ajax.post<ExperienceSetData>('/experience/update-set', { id: languageSet.id, updates: values });
+
+         if (!updatedSet) {
+            throw new Error('Failed to update experience set');
+         }
+
+         window.location.reload();
+         return { success: true };
+      } catch (error) {
+         throw error;
+      }
+   };
+
+   console.log('Form submitted with data:', languageSet);
+   return (
+      <Form initialValues={{...languageSet}} submitLabel="Save Changes" onSubmit={handleSubmit} editMode>
+         <FormInput fieldName="position" label="Position" />
+         <FormInput fieldName="slug" label="Slug" />
+         <FormInput fieldName="summary" label="Summary" multiline minRows={5} />
+         <FormInput fieldName="description" label="Description" multiline minRows={10} />
+         <FormInput fieldName="responsibilities" label="Responsibilities" multiline minRows={5} />
+      </Form>
+   );
+}

--- a/src/components/forms/EditExperienceSetForm/EditExperienceSetForm.tsx
+++ b/src/components/forms/EditExperienceSetForm/EditExperienceSetForm.tsx
@@ -28,9 +28,8 @@ export default function EditExperienceSetForm({ language_set = 'en' }: EditExper
       }
    };
 
-   console.log('Form submitted with data:', languageSet);
    return (
-      <Form initialValues={{...languageSet}} submitLabel="Save Changes" onSubmit={handleSubmit} editMode>
+      <Form initialValues={Object(languageSet)} submitLabel="Save Changes" onSubmit={handleSubmit} editMode>
          <FormInput fieldName="position" label="Position" />
          <FormInput fieldName="slug" label="Slug" />
          <FormInput fieldName="summary" label="Summary" multiline minRows={5} />

--- a/src/components/forms/EditExperienceSetForm/EditExperienceSetForm.types.ts
+++ b/src/components/forms/EditExperienceSetForm/EditExperienceSetForm.types.ts
@@ -1,0 +1,3 @@
+export interface EditExperienceSetFormProps {
+   language_set?: string;
+}


### PR DESCRIPTION
## [FRD-90] Description
This pull request introduces an edit mode for managing experience sets in the `ExperienceSetsSection` component and adds a new form component for editing experience set details. The most significant changes include implementing the `EditExperienceSetForm` component, updating the `ExperienceSetsSection` component to support edit mode, and defining a new type for the form's props.

### New functionality for editing experience sets:

* **Added `EditExperienceSetForm` component**: This new form component allows users to edit details of an experience set, including fields like position, slug, summary, description, and responsibilities. It uses the `useAjax` hook to submit updates to the server and reloads the page upon successful submission. (`src/components/forms/EditExperienceSetForm/EditExperienceSetForm.tsx`, [src/components/forms/EditExperienceSetForm/EditExperienceSetForm.tsxR1-R41](diffhunk://#diff-97cba0629a7d71ace75b251297edd9b12defef6a16c984ebdfc2f85dfeb1bf45R1-R41))

* **Defined `EditExperienceSetFormProps` type**: Introduced a new TypeScript interface to define the props for the `EditExperienceSetForm` component, including an optional `language_set` property. (`src/components/forms/EditExperienceSetForm/EditExperienceSetForm.types.ts`, [src/components/forms/EditExperienceSetForm/EditExperienceSetForm.types.tsR1-R3](diffhunk://#diff-5ce029c2aad9cc41aad7982b735effe307a13d3b3844a3defac5ac7cb955f599R1-R3))

### Updates to `ExperienceSetsSection`:

* **Integrated edit mode**: Added state management (`useState`) and UI elements (e.g., an edit button) to toggle between viewing and editing experience sets. The edit mode dynamically renders the `EditExperienceSetForm` component. (`src/components/content/admin/experience/ExperienceDetailsContent/common/ExperienceSetsSection.tsx`, [[1]](diffhunk://#diff-345b54491355f73c4dd4a340fc8f0138674d787881e2819525c25b64608284e7L1-R34) [[2]](diffhunk://#diff-345b54491355f73c4dd4a340fc8f0138674d787881e2819525c25b64608284e7R70)

* **Refactored imports**: Updated import statements for consistency in single quotes and added imports for new dependencies like `useState`, `IconButton`, and `EditExperienceSetForm`. (`src/components/content/admin/experience/ExperienceDetailsContent/common/ExperienceSetsSection.tsx`, [src/components/content/admin/experience/ExperienceDetailsContent/common/ExperienceSetsSection.tsxL1-R34](diffhunk://#diff-345b54491355f73c4dd4a340fc8f0138674d787881e2819525c25b64608284e7L1-R34))

[FRD-90]: https://feliperamosdev.atlassian.net/browse/FRD-90?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ