### PR TITLE
[FRD-92] Markdown Display

### DIFF
--- a/src/components/common/Markdown/Markdown.module.scss
+++ b/src/components/common/Markdown/Markdown.module.scss
@@ -1,0 +1,21 @@
+@use '@/style/variables' as *;
+
+.Markdown {
+   p {
+      margin-bottom: 1.5rem;
+      font-size: 1rem;
+      line-height: 1.5rem;
+   }
+
+   h1, h2, h3, h4, h5, h6 {
+      margin-top: 1rem;
+      margin-bottom: 0.5rem;
+   }
+
+   ul {
+      li {
+         margin-bottom: 0.5rem;
+         margin-left: 1.4rem;
+      }
+   }
+}

--- a/src/components/common/Markdown/Markdown.tsx
+++ b/src/components/common/Markdown/Markdown.tsx
@@ -1,0 +1,16 @@
+import { parseCSS } from '@/utils/parse';
+import { MarkdownProps } from './Markdown.types';
+import styles from './Markdown.module.scss';
+import { marked } from 'marked';
+
+export default function Markdown({ className, value }: MarkdownProps) {
+   const htmlValue = marked(value);
+   const CSS = parseCSS(className, [
+      'Markdown',
+      styles.Markdown,
+   ]);
+   
+   return (
+      <div className={CSS} dangerouslySetInnerHTML={{ __html: htmlValue }}></div>
+   );
+}

--- a/src/components/common/Markdown/Markdown.types.ts
+++ b/src/components/common/Markdown/Markdown.types.ts
@@ -1,0 +1,4 @@
+export interface MarkdownProps {
+   value: string;
+   className?: string;
+}

--- a/src/components/common/index.tsx
+++ b/src/components/common/index.tsx
@@ -3,3 +3,5 @@ export { default as Container } from './Container/Container';
 export { default as Logo } from './Logo/Logo';
 export { default as SocialLinks } from './SocialLinks/SocialLinks';
 export { default as Spinner } from './Spinner/Spinner';
+export { default as Markdown } from './Markdown/Markdown';
+export { default as TableBase } from './TableBase/TableBase';

--- a/src/components/content/admin/company/CompanyDetailsContent/slices/CompanyDetailsSets.tsx
+++ b/src/components/content/admin/company/CompanyDetailsContent/slices/CompanyDetailsSets.tsx
@@ -1,4 +1,4 @@
-import { Card } from "@/components/common";
+import { Card, Markdown } from "@/components/common";
 import EditCompanySetForm from "@/components/forms/EditCompanySetForm/EditCompanySetForm";
 import WidgetHeader from "@/components/headers/WidgetHeader/WidgetHeader";
 import TabsContent from "@/components/layout/TabsContent/TabsContent";
@@ -55,7 +55,7 @@ export default function CompanyDetailsSets(): React.ReactElement {
                      </DataContainer>
                      <DataContainer>
                         <label>Description:</label>
-                        <p>{languageSet.description || 'No description available.'}</p>
+                        <Markdown value={languageSet.description || 'No description available.'} />
                      </DataContainer>
                   </div>
                );

--- a/src/components/content/admin/experience/ExperienceDetailsContent/ExperienceDetailsContent.module.scss
+++ b/src/components/content/admin/experience/ExperienceDetailsContent/ExperienceDetailsContent.module.scss
@@ -25,7 +25,6 @@
 
       p {
          flex: 4;
-         font-size: 1.1rem;
       }
    }
 

--- a/src/components/content/admin/experience/ExperienceDetailsContent/common/ExperienceSetsSection.tsx
+++ b/src/components/content/admin/experience/ExperienceDetailsContent/common/ExperienceSetsSection.tsx
@@ -69,7 +69,7 @@ export default function ExperienceSetsSection(): React.ReactElement {
                      </FieldWrap>
                      <FieldWrap vertical>
                         <label>Description:</label>
-                        <Markdown value={languageSet.description || ''} />
+                        <Markdown value={languageSet.description || 'No description available.'} />
                      </FieldWrap>
                      <FieldWrap vertical>
                         <label>Responsibilities:</label>

--- a/src/components/content/admin/experience/ExperienceDetailsContent/common/ExperienceSetsSection.tsx
+++ b/src/components/content/admin/experience/ExperienceDetailsContent/common/ExperienceSetsSection.tsx
@@ -1,4 +1,4 @@
-import { Card } from '@/components/common';
+import { Card, Markdown } from '@/components/common';
 import TabsContent from '@/components/layout/TabsContent/TabsContent';
 import { TabOption } from '@/components/layout/TabsContent/TabsContent.types';
 import { useExperienceDetails } from '../ExperienceDetailsContext';
@@ -65,15 +65,15 @@ export default function ExperienceSetsSection(): React.ReactElement {
 
                      <FieldWrap vertical>
                         <label>Summary:</label>
-                        <p>{languageSet.summary || 'No summary available.'}</p>
+                        <Markdown value={languageSet.summary || 'No summary available.'} />
                      </FieldWrap>
                      <FieldWrap vertical>
                         <label>Description:</label>
-                        <p>{languageSet.description || 'No description available.'}</p>
+                        <Markdown value={languageSet.description || ''} />
                      </FieldWrap>
                      <FieldWrap vertical>
                         <label>Responsibilities:</label>
-                        <p>{languageSet.responsibilities || 'No responsibilities available.'}</p>
+                        <Markdown value={languageSet.responsibilities || 'No responsibilities available.'} />
                      </FieldWrap>
                   </div>
                );

--- a/src/components/content/admin/skill/SkillDetailsContent/subcomponents/SkillDetailsSets.tsx
+++ b/src/components/content/admin/skill/SkillDetailsContent/subcomponents/SkillDetailsSets.tsx
@@ -1,4 +1,4 @@
-import { Card } from '@/components/common';
+import { Card, Markdown } from '@/components/common';
 import WidgetHeader from '@/components/headers/WidgetHeader/WidgetHeader';
 import DataContainer from '@/components/layout/DataContainer/DataContainer';
 import TabsContent from '@/components/layout/TabsContent/TabsContent';
@@ -51,7 +51,7 @@ export default function SkillDetailsSets(): React.ReactElement {
                   <div className="skill-content" key={option.value}>
                      <DataContainer>
                         <label>Journey:</label>
-                        <p>{languageSet.journey || 'No journey available.'}</p>
+                        <Markdown value={languageSet.journey || 'No journey available.'} />
                      </DataContainer>
                   </div>
                );


### PR DESCRIPTION
## [FRD-92] Description
This pull request introduces a new reusable `Markdown` component for rendering markdown content across the application. The changes include creating the component, integrating it into existing sections, and updating styling for markdown content.

### New `Markdown` Component Implementation:
* Added a new `Markdown` component in `src/components/common/Markdown/Markdown.tsx` that uses the `marked` library to parse markdown and the `parseCSS` utility for dynamic styling.
* Defined the `MarkdownProps` interface in `src/components/common/Markdown/Markdown.types.ts` to specify the component's props (`value` and optional `className`).
* Added corresponding styles for the `Markdown` component in `src/components/common/Markdown/Markdown.module.scss` to define typography and spacing for markdown elements like paragraphs, headings, and lists.

### Integration of the `Markdown` Component:
* Registered the `Markdown` component in the common components index file (`src/components/common/index.tsx`).
* Replaced plain `<p>` tags with the `Markdown` component in the following files:
  - `CompanyDetailsSets.tsx` for rendering descriptions.
  - `ExperienceSetsSection.tsx` for rendering summaries, descriptions, and responsibilities.
  - `SkillDetailsSets.tsx` for rendering journeys.

### Styling Adjustments:
* Removed redundant font-size styling for `<p>` tags in `ExperienceDetailsContent.module.scss` to avoid conflicts with the new `Markdown` styles.

[FRD-92]: https://feliperamosdev.atlassian.net/browse/FRD-92?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ