### PR TITLE
[FRD-93] Date Display Component

### DIFF
--- a/src/components/common/DateView/DateView.tsx
+++ b/src/components/common/DateView/DateView.tsx
@@ -1,0 +1,27 @@
+import dayjs from 'dayjs';
+import { DateViewProps } from './DateView.types';
+import { parseCSS } from '@/utils/parse';
+
+export default function DateView({ className, type = 'abbMonth-fullYear', date, locale = 'en', ...props }: DateViewProps) {
+   const spanProps = {
+      ...props,
+      className: parseCSS(className, [
+         'DateView'
+      ])
+   };
+
+   switch (type) {
+      case 'locale-standard':
+         return <span {...spanProps}>{dayjs(date).locale(locale).format('LL')}</span>;
+      case 'abbMonth-fullYear':
+         return <span {...spanProps}>{dayjs(date).locale(locale).format('MMM YYYY')}</span>;
+      case 'fullMonth-fullYear':
+         return <span {...spanProps}>{dayjs(date).locale(locale).format('MMMM YYYY')}</span>;
+      case 'fullMonth-abbYear':
+         return <span {...spanProps}>{dayjs(date).locale(locale).format('MMMM YY')}</span>;
+      case 'abbMonth-abbYear':
+         return <span {...spanProps}>{dayjs(date).locale(locale).format('MMM YY')}</span>;
+      default:
+         return null;
+   }
+};

--- a/src/components/common/DateView/DateView.types.ts
+++ b/src/components/common/DateView/DateView.types.ts
@@ -1,0 +1,6 @@
+export interface DateViewProps {
+   className?: string | string[];
+   date: Date | string | number;
+   locale?: string;
+   type?: 'locale-standard' | 'abbMonth-fullYear' | 'fullMonth-fullYear' | 'fullMonth-abbYear' | 'abbMonth-abbYear';
+}

--- a/src/components/common/Markdown/Markdown.module.scss
+++ b/src/components/common/Markdown/Markdown.module.scss
@@ -1,6 +1,8 @@
 @use '@/style/variables' as *;
 
 .Markdown {
+   width: 100%;
+
    p {
       margin-bottom: 1.5rem;
       font-size: 1rem;

--- a/src/components/common/index.tsx
+++ b/src/components/common/index.tsx
@@ -1,5 +1,6 @@
 export { default as Card } from './Card/Card';
 export { default as Container } from './Container/Container';
+export { default as DateView } from './DateView/DateView';
 export { default as Logo } from './Logo/Logo';
 export { default as SocialLinks } from './SocialLinks/SocialLinks';
 export { default as Spinner } from './Spinner/Spinner';

--- a/src/components/content/admin/experience/ExperienceDetailsContent/ExperienceDetailsContent.module.scss
+++ b/src/components/content/admin/experience/ExperienceDetailsContent/ExperienceDetailsContent.module.scss
@@ -23,7 +23,8 @@
          font-weight: 600;
       }
 
-      p {
+      p,
+      span {
          flex: 4;
       }
    }

--- a/src/components/content/admin/experience/ExperienceDetailsContent/common/ExperienceDetailsSection.tsx
+++ b/src/components/content/admin/experience/ExperienceDetailsContent/common/ExperienceDetailsSection.tsx
@@ -1,4 +1,4 @@
-import { Card } from '@/components/common';
+import { Card, DateView } from '@/components/common';
 import { useExperienceDetails } from '../ExperienceDetailsContext';
 import FieldWrap from './ExperienceDetailsFieldWrap';
 import classNames from '../ExperienceDetailsContent.module.scss';
@@ -43,11 +43,11 @@ export default function ExperienceDetailsSection() {
                </FieldWrap>
                <FieldWrap>
                   <label>Start Date:</label>
-                  <p>{new Date(experience.start_date).toLocaleDateString()}</p>
+                  <DateView date={experience.start_date} />
                </FieldWrap>
                <FieldWrap>
                   <label>End Date:</label>
-                  <p>{new Date(experience.end_date).toLocaleDateString()}</p>
+                  <DateView date={experience.end_date} />
                </FieldWrap>
             </Fragment>
          )}

--- a/src/components/widgets/ExperiencesWidget/experienceWidget.config.tsx
+++ b/src/components/widgets/ExperiencesWidget/experienceWidget.config.tsx
@@ -1,12 +1,14 @@
 import { IColumnConfig } from '@/components/common/TableBase';
 import { WidgetExperienceObject } from './ExperiencesWidget.types';
 import { SkillBadge } from '@/components/badges';
+import { DateView } from '@/components/common';
 
 export const experienceWidgetColumns: IColumnConfig[] = [
    {
       propKey: 'title',
       label: 'Title',
       align: 'left',
+      minWidth: 180,
       format: (_: unknown, item: unknown) => {
          const row = item as WidgetExperienceObject;
 
@@ -48,9 +50,10 @@ export const experienceWidgetColumns: IColumnConfig[] = [
       propKey: 'data',
       label: 'Start Date',
       align: 'left',
+      minWidth: 230,
       format: (_: unknown, item: unknown) => {
          const row = item as WidgetExperienceObject;
-         return `${new Date(row.start_date).toLocaleDateString()} to ${new Date(row.end_date).toLocaleDateString()}`;
+         return <p><DateView date={row.start_date} /> / <DateView date={row.end_date} /></p>;
       }
    },
    {


### PR DESCRIPTION
## [FRD-93] Description
This pull request introduces a reusable `DateView` component for consistent date formatting across the application, updates its usage in multiple places, and includes minor style adjustments. The most important changes are grouped into the creation and integration of the `DateView` component, as well as style refinements.

### Creation and Integration of `DateView` Component:
* **New `DateView` Component**: Added a reusable `DateView` component in `src/components/common/DateView/DateView.tsx` with various formatting options and locale support.
* **Type Definition**: Introduced the `DateViewProps` interface in `src/components/common/DateView/DateView.types.ts` to define the props for the `DateView` component.
* **Component Export**: Registered `DateView` in the common components index file for easier imports.
* **Admin Experience Details**: Replaced inline date formatting with the `DateView` component in `ExperienceDetailsSection.tsx` for start and end dates.
* **Experiences Widget**: Updated the `experienceWidgetColumns` configuration to use `DateView` for displaying start and end dates in a consistent format.

### Style Refinements:
* **Markdown Component**: Added a `width: 100%` style to the `.Markdown` class in `Markdown.module.scss`.
* **Experience Details Styling**: Updated `ExperienceDetailsContent.module.scss` to apply consistent styles to both `p` and `span` elements.

[FRD-93]: https://feliperamosdev.atlassian.net/browse/FRD-93?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ