### PR TITLE
[FRD-100] Metadata for admin pages

### DIFF
--- a/src/app/admin/company/[company_id]/page.tsx
+++ b/src/app/admin/company/[company_id]/page.tsx
@@ -2,7 +2,12 @@ import { AdminPageBase } from '@/components/layout';
 import { headersAcceptLanguage } from '@/helpers';
 import { CompanyData } from '@/types/database.types';
 import ajax from '@/hooks/useAjax';
-import CompanyDetailsContent from '@/components/content/admin/company/CompanyDetailsContent/CompanyDetailsContent';
+import { CompanyDetailsContent } from '@/components/content/admin/company';
+
+export const metadata = {
+   title: 'Company Details - Admin Dashboard',
+   description: 'View and manage company details in the admin dashboard',
+};
 
 export default async function CompanyPage({ params }: { params: Promise<{ company_id: string }> }) {
    const { company_id } = await params;

--- a/src/app/admin/company/create/page.tsx
+++ b/src/app/admin/company/create/page.tsx
@@ -1,6 +1,11 @@
-import CreateCompanyContent from '@/components/content/admin/company/CreateCompanyContent/CreateCompanyContent';
+import { CreateCompanyContent } from '@/components/content/admin/company';
 import { AdminPageBase } from '@/components/layout';
 import { headersAcceptLanguage } from '@/helpers';
+
+export const metadata = {
+   title: 'Create Company - Admin Dashboard',
+   description: 'Create a new company in the admin dashboard',
+};
 
 export default async function CreateCompanyPage() {
    const detectedLang = await headersAcceptLanguage();

--- a/src/app/admin/experience/[experience_id]/page.tsx
+++ b/src/app/admin/experience/[experience_id]/page.tsx
@@ -4,6 +4,11 @@ import { headersAcceptLanguage } from '@/helpers';
 import { ExperienceData } from '@/types/database.types';
 import ajax from '@/hooks/useAjax';
 
+export const metadata = {
+   title: 'Experience Details - Admin Dashboard',
+   description: 'View and manage experience details in the admin dashboard',
+};
+
 export default async function AdminExperiencePage({ params }: { params: Promise<{ experience_id: string }> }) {
    const { experience_id } = await params;
    const detectedLang = await headersAcceptLanguage();

--- a/src/app/admin/experience/create/page.tsx
+++ b/src/app/admin/experience/create/page.tsx
@@ -2,6 +2,11 @@ import { CreateExperienceContent } from '@/components/content/admin/experience';
 import { AdminPageBase } from '@/components/layout';
 import { headersAcceptLanguage } from '@/helpers';
 
+export const metadata = {
+   title: 'Create Experience - Admin Dashboard',
+   description: 'Create a new experience in the admin dashboard',
+};
+
 export default async function CreateExperiencePage() {
    const detectedLang = await headersAcceptLanguage();
 

--- a/src/app/admin/login/page.tsx
+++ b/src/app/admin/login/page.tsx
@@ -3,6 +3,11 @@ import { LoginContent } from '@/components/content/admin';
 import { headersAcceptLanguage } from '@/helpers';
 import { AuthProvider } from '@/services';
 
+export const metadata = {
+   title: 'Admin Login - Admin Dashboard',
+   description: 'Login to the admin dashboard to manage your application',
+};
+
 export default async function LoginPage() {
    const detectedLang = await headersAcceptLanguage();
 

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,13 +1,18 @@
-import AdminPainelContent from '@/components/content/admin/DashboardContent/DashboardContent';
+import { DashboardContent } from '@/components/content/admin';
 import { AdminPageBase } from '@/components/layout';
 import { headersAcceptLanguage } from '@/helpers';
+
+export const metadata = {
+   title: 'Admin Dashboard - Manage your application dashboard',
+   description: 'Admin Dashboard - Manage your application',
+};
 
 export default async function AdminDashboardPage() {
    const detectedLang = await headersAcceptLanguage();
 
    return (
       <AdminPageBase language={detectedLang}>
-         <AdminPainelContent />
+         <DashboardContent />
       </AdminPageBase>
    );
 }

--- a/src/app/admin/skill/[skill_id]/page.tsx
+++ b/src/app/admin/skill/[skill_id]/page.tsx
@@ -1,8 +1,13 @@
-import SkillDetailsContent from '@/components/content/admin/skill/SkillDetailsContent/SkillDetailsContent';
+import { SkillDetailsContent } from '@/components/content/admin/skill';
 import { AdminPageBase } from '@/components/layout';
 import { SkillData } from '@/types/database.types';
 import ajax from '@/hooks/useAjax';
 import { headersAcceptLanguage } from '@/helpers';
+
+export const metadata = {
+   title: 'Skill Details - Admin Dashboard',
+   description: 'View and manage skill details in the admin dashboard',
+};
 
 export default async function SkillDetailsPage({ params }: { params: Promise<{ skill_id: string }> }): Promise<React.ReactElement | null> {
    const { skill_id } = await params;

--- a/src/app/admin/skill/create/page.tsx
+++ b/src/app/admin/skill/create/page.tsx
@@ -1,6 +1,11 @@
-import { CreateSkillContent } from "@/components/content/admin/skill";
-import { AdminPageBase } from "@/components/layout";
-import { headersAcceptLanguage } from "@/helpers";
+import { CreateSkillContent } from '@/components/content/admin/skill';
+import { AdminPageBase } from '@/components/layout';
+import { headersAcceptLanguage } from '@/helpers';
+
+export const metadata = {
+   title: 'Create Skill - Admin Dashboard',
+   description: 'Create a new skill in the admin dashboard',
+};
 
 export default async function CreateSkillPage() {
    const detectedLang = await headersAcceptLanguage();

--- a/src/components/content/admin/company/index.tsx
+++ b/src/components/content/admin/company/index.tsx
@@ -1,1 +1,2 @@
 export { default as CreateCompanyContent } from './CreateCompanyContent/CreateCompanyContent';
+export { default as CompanyDetailsContent } from './CompanyDetailsContent/CompanyDetailsContent';

--- a/src/components/content/admin/skill/index.tsx
+++ b/src/components/content/admin/skill/index.tsx
@@ -1,1 +1,2 @@
 export { default as CreateSkillContent } from './CreateSkillContent/CreateSkillContent';
+export { default as SkillDetailsContent } from './SkillDetailsContent/SkillDetailsContent';


### PR DESCRIPTION
## [FRD-100] Description
This pull request introduces two main improvements: the addition of `metadata` objects for SEO and page clarity across admin-related pages, and the consolidation of imports for cleaner and more maintainable code. Below are the most important changes grouped by theme.

### Metadata Addition for SEO and Page Clarity:
* Added `metadata` objects to multiple admin pages, including titles and descriptions, to improve SEO and provide better context for each page. Examples include:
  - `CompanyPage` now includes metadata with the title "Company Details - Admin Dashboard" and a description. 
  - `CreateCompanyPage` includes metadata with the title "Create Company - Admin Dashboard" and a description. 
  - Similar updates were made for experience, skill, and login pages.

### Import Consolidation for Cleaner Code:
* Consolidated imports for components by using index files instead of deeply nested paths. Examples include:
  - Updated `CompanyPage` and `CreateCompanyPage` to import `CompanyDetailsContent` and `CreateCompanyContent` from the `admin/company` index file. 
  - Updated `SkillDetailsPage` and `CreateSkillPage` to import `SkillDetailsContent` and `CreateSkillContent` from the `admin/skill` index file.
  - Replaced `AdminPainelContent` with `DashboardContent` in `AdminDashboardPage` for consistency. 