### PR TITLE
[FRD-105] Server Side Ajax Issue

### DIFF
--- a/src/services/Ajax/Ajax.ts
+++ b/src/services/Ajax/Ajax.ts
@@ -17,7 +17,7 @@ export default class Ajax {
          },
          withCredentials: config.withCredentials || true,
          httpsAgent: new https.Agent({
-            rejectUnauthorized: (process.env.NEXT_PUBLIC_NODE_ENV !== 'development'),
+            rejectUnauthorized: false,
          }),
          ...config
       });


### PR DESCRIPTION
This pull request modifies the `Ajax` service to disable SSL certificate validation by setting `rejectUnauthorized` to `false`. This change may have security implications, particularly in production environments.

Currently I have a self-signed certificate, so this will be disabled for now.

* **SSL Certificate Validation Disabled**:
  * [`src/services/Ajax/Ajax.ts`](diffhunk://#diff-e536dd6bfff0c3d3e8be47688eda80017a69a5029b6102edb3274d8af9f2ca4cL20-R20): Updated the `httpsAgent` configuration in the `Ajax` class to set `rejectUnauthorized` to `false`, disabling SSL certificate validation.