### PR TITLE
[FRD-110] Create CV - Page

### DIFF
--- a/src/app/admin/curriculum/create/page.tsx
+++ b/src/app/admin/curriculum/create/page.tsx
@@ -1,0 +1,13 @@
+import { CreateCurriculumContent } from "@/components/content/admin/curriculum";
+import { AdminPageBase } from "@/components/layout";
+import { headersAcceptLanguage } from "@/helpers";
+
+export default async function CurriculumCreatePage() {
+   const detectedLocale = await headersAcceptLanguage();
+
+   return (
+      <AdminPageBase language={detectedLocale}>
+         <CreateCurriculumContent />
+      </AdminPageBase>
+   );
+}

--- a/src/components/common/Card/Card.tsx
+++ b/src/components/common/Card/Card.tsx
@@ -13,6 +13,7 @@ const Card = forwardRef<HTMLDivElement, CardProps>((props, ref) => {
       className = [],
       testId,
       children,
+      onClick,
       ...others
    } = props;
 
@@ -25,7 +26,7 @@ const Card = forwardRef<HTMLDivElement, CardProps>((props, ref) => {
    ]);
 
    return (
-      <div ref={ref} data-testid={testId} className={classNames} {...others}>
+      <div ref={ref} data-testid={testId} className={classNames} onClick={onClick} {...others}>
          {children}
       </div>
    );

--- a/src/components/common/Card/Card.types.ts
+++ b/src/components/common/Card/Card.types.ts
@@ -13,5 +13,6 @@ export interface CardProps {
    padding?: SizeKeyword;
    shadowColor?: string;
    style?: React.CSSProperties;
+   onClick?: React.MouseEventHandler<HTMLDivElement>;
    children?: React.ReactNode;
 }

--- a/src/components/content/admin/curriculum/CreateCurriculumContent/CreateCurriculumContent.text.ts
+++ b/src/components/content/admin/curriculum/CreateCurriculumContent/CreateCurriculumContent.text.ts
@@ -1,0 +1,11 @@
+import { TextResources } from '@/services';
+
+const textResources = new TextResources();
+
+textResources.create('CreateCurriculumForm.pageTitle', 'Create Curriculum');
+textResources.create('CreateCurriculumForm.pageTitle', 'Criar Currículo', 'pt');
+
+textResources.create('CreateCurriculumForm.pageDescription', 'Fill in the details to create a new curriculum.');
+textResources.create('CreateCurriculumForm.pageDescription', 'Preencha os detalhes para criar um novo currículo.', 'pt');
+
+export default textResources;

--- a/src/components/content/admin/curriculum/CreateCurriculumContent/CreateCurriculumContent.tsx
+++ b/src/components/content/admin/curriculum/CreateCurriculumContent/CreateCurriculumContent.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { Container } from '@/components/common';
+import CreateCurriculumForm from '@/components/forms/curriculums/CreateCurriculumForm/CreateCurriculumForm';
+import { PageHeader } from '@/components/headers';
+import texts from './CreateCurriculumContent.text';
+import { useTextResources } from '@/services/TextResources/TextResourcesProvider';
+
+export default function CreateCurriculumContent() {
+   const { textResources } = useTextResources(texts);
+
+   return (
+      <div className="CreateCurriculumContent">
+         <PageHeader
+            title={textResources.getText('CreateCurriculumForm.pageTitle')}
+            description={textResources.getText('CreateCurriculumForm.pageDescription')}
+         />
+
+         <Container>
+            <CreateCurriculumForm />
+         </Container>
+      </div>
+   );
+}

--- a/src/components/content/admin/curriculum/index.tsx
+++ b/src/components/content/admin/curriculum/index.tsx
@@ -1,0 +1,1 @@
+export { default as CreateCurriculumContent } from './CreateCurriculumContent/CreateCurriculumContent';

--- a/src/components/forms/curriculums/CreateCurriculumForm/CreateCurriculumForm.text.ts
+++ b/src/components/forms/curriculums/CreateCurriculumForm/CreateCurriculumForm.text.ts
@@ -1,0 +1,41 @@
+import { TextResources } from '@/services';
+
+const textResources = new TextResources();
+
+textResources.create('CreateCurriculumForm.title.label', 'CV Title');
+textResources.create('CreateCurriculumForm.title.label', 'Título do CV', 'pt');
+
+textResources.create('CreateCurriculumForm.title.placeholder', 'Enter curriculum title');
+textResources.create('CreateCurriculumForm.title.placeholder', 'Digite o título do currículo', 'pt');
+
+textResources.create('CreateCurriculumForm.notes.label', 'Reminder Notes');
+textResources.create('CreateCurriculumForm.notes.label', 'Notas de Lembrete', 'pt');
+
+textResources.create('CreateCurriculumForm.notes.placeholder', 'Enter a note to identify this curriculum');
+textResources.create('CreateCurriculumForm.notes.placeholder', 'Digite uma nota para identificar este currículo', 'pt');
+
+textResources.create('CreateCurriculumForm.professional_title.label', 'Professional Title');
+textResources.create('CreateCurriculumForm.professional_title.label', 'Título Profissional', 'pt');
+
+textResources.create('CreateCurriculumForm.professional_title.placeholder', 'Enter your professional title');
+textResources.create('CreateCurriculumForm.professional_title.placeholder', 'Digite seu título profissional', 'pt');
+
+textResources.create('CreateCurriculumForm.summary.label', 'Summary');
+textResources.create('CreateCurriculumForm.summary.label', 'Resumo', 'pt');
+
+textResources.create('CreateCurriculumForm.summary.placeholder', 'Enter a summary for this curriculum');
+textResources.create('CreateCurriculumForm.summary.placeholder', 'Digite um resumo para este currículo', 'pt');
+
+textResources.create('CreateCurriculumForm.is_master.label', 'Master Curriculum');
+textResources.create('CreateCurriculumForm.is_master.label', 'Currículo Principal', 'pt');
+
+textResources.create('CreateCurriculumForm.submit.label', 'Create');
+textResources.create('CreateCurriculumForm.submit.label', 'Criar', 'pt');
+
+textResources.create('CreateCurriculumForm.cv_experiences.label', 'Experiences');
+textResources.create('CreateCurriculumForm.cv_experiences.label', 'Experiências', 'pt');
+
+textResources.create('CreateCurriculumForm.skills.label', 'Skills');
+textResources.create('CreateCurriculumForm.skills.label', 'Habilidades', 'pt');
+
+export default textResources;

--- a/src/components/forms/curriculums/CreateCurriculumForm/CreateCurriculumForm.tsx
+++ b/src/components/forms/curriculums/CreateCurriculumForm/CreateCurriculumForm.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import { Card } from '@/components/common';
+import { CardProps } from '@/components/common/Card/Card.types';
+import { ContentSidebar } from '@/components/layout';
+import { Form, FormInput, FormMultiSelectChip, FormSubmit } from '@/hooks';
+import { FormValues } from '@/hooks/Form/Form.types';
+import { useTextResources } from '@/services/TextResources/TextResourcesProvider';
+import { Save } from '@mui/icons-material';
+import { Fragment, useEffect } from 'react';
+import texts from './CreateCurriculumForm.text';
+import { useAjax } from '@/hooks/useAjax';
+import { CVData } from '@/types/database.types';
+import { useRouter } from 'next/navigation';
+import FormCheckSwitch from '@/hooks/Form/inputs/FormCheckSwitch';
+import FormCheckboxList from '@/hooks/Form/inputs/FormCheckboxList';
+import { loadExperiencesListOptions, loadSkillsOptions } from '@/helpers/database.helpers';
+import WidgetHeader from '@/components/headers/WidgetHeader/WidgetHeader';
+
+export default function CreateCurriculumForm() {
+   const { textResources } = useTextResources(texts);
+   const ajax = useAjax();
+   const router = useRouter();
+
+   const cardProps: CardProps = { padding: 'm' }
+
+   const handleSubmit = async (data: FormValues) => {
+      try {
+         const created = await ajax.post<CVData>('/curriculum/create', data);
+
+         if (!created.success) {
+            console.error("Error creating curriculum:", created.message);
+            return created;
+         }
+
+         console.log("Curriculum created successfully:", created.data);
+         router.push(`/admin/curriculum/${created.data.id}`);
+         return { success: true };
+      } catch (error) {
+         console.error("Error creating curriculum:", error);
+         return error;
+      }
+   }
+
+   return (
+      <Form hideSubmit onSubmit={handleSubmit}>
+         <ContentSidebar>
+            <Fragment>
+               <Card {...cardProps}>
+                  <FormInput
+                     fieldName="title"
+                     label={textResources.getText('CreateCurriculumForm.title.label')}
+                     placeholder={textResources.getText('CreateCurriculumForm.title.placeholder')}
+                  />
+               </Card>
+
+               <Card {...cardProps}>
+                  <FormInput
+                     fieldName="professional_title"
+                     label={textResources.getText('CreateCurriculumForm.professional_title.label')}
+                     placeholder={textResources.getText('CreateCurriculumForm.professional_title.placeholder')}
+                  />
+                  <FormInput
+                     fieldName="summary"
+                     label={textResources.getText('CreateCurriculumForm.summary.label')}
+                     placeholder={textResources.getText('CreateCurriculumForm.summary.placeholder')}
+                     multiline
+                     minRows={5}
+                  />
+               </Card>
+
+               <Card {...cardProps}>
+                  <FormCheckboxList
+                     fieldName="cv_experiences"
+                     label={textResources.getText('CreateCurriculumForm.cv_experiences.label')}
+                     loadOptions={() => loadExperiencesListOptions(ajax, textResources.currentLanguage)}
+                  />
+               </Card>
+            </Fragment>
+
+            <Fragment>
+               <Card {...cardProps}>
+                  <FormCheckSwitch
+                     fieldName="is_master"
+                     label={textResources.getText('CreateCurriculumForm.is_master.label')}
+                  />
+               </Card>
+               <Card {...cardProps}>
+                  <FormInput
+                     fieldName="notes"
+                     label={textResources.getText('CreateCurriculumForm.notes.label')}
+                     placeholder={textResources.getText('CreateCurriculumForm.notes.placeholder')}
+                     multiline
+                     minRows={3}
+                  />
+               </Card>
+
+               <Card {...cardProps}>
+                  <FormMultiSelectChip
+                     fieldName="cv_skills"
+                     label={textResources.getText('CreateCurriculumForm.skills.label')}
+                     loadOptions={() => loadSkillsOptions(ajax, textResources)}
+                  />
+               </Card>
+
+               <Card {...cardProps}>
+                  <FormSubmit startIcon={<Save />} label={textResources.getText('CreateCurriculumForm.submit.label')} />
+               </Card>
+            </Fragment>
+         </ContentSidebar>
+      </Form>
+   );
+}

--- a/src/components/forms/experiences/CreateExperienceForm/CreateExperienceForm.config.ts
+++ b/src/components/forms/experiences/CreateExperienceForm/CreateExperienceForm.config.ts
@@ -29,36 +29,6 @@ export const createExperience = async (data: FormValues, ajax: Ajax, router: App
    }
 }
 
-export const handleExperienceLoadOptions = async (ajax: Ajax, textResources: TextResources): Promise<FormSelectOption[]> => {
-   const { success, data, message } = await ajax.get<CompanyData[]>('/company/query', {
-      params: { language_set: textResources.currentLanguage }
-   });
-
-   if (!success) {
-      console.error('Failed to load companies:', message);
-      return [];
-   }
-
-   return data.map((company: CompanyData) => ({
-      value: Number(company.id),
-      label: String(company.company_name)
-   }));
-}
-
-export const handleSkillsLoadOptions = async (ajax: Ajax, textResources: TextResources): Promise<FormSelectOption[]> => {
-   const { success, data, message } = await ajax.get<SkillData[]>('/skill/query', { params: { language_set: textResources.currentLanguage } });
-
-   if (!success) {
-      console.error('Failed to load skills:', message);
-      return [];
-   }
-
-   return data.map((skill: SkillData) => ({
-      value: Number(skill.id),
-      label: String(skill.name),
-   }));
-}
-
 export const typeOptions = [
    { value: 'contract', label: 'Contract' },
    { value: 'full_time', label: 'Full Time' },

--- a/src/components/forms/experiences/CreateExperienceForm/CreateExperienceForm.tsx
+++ b/src/components/forms/experiences/CreateExperienceForm/CreateExperienceForm.tsx
@@ -12,10 +12,11 @@ import { Save } from '@mui/icons-material';
 import { useRouter } from 'next/navigation';
 import FormSelect from '@/hooks/Form/inputs/FormSelect';
 import { useTextResources } from '@/services/TextResources/TextResourcesProvider';
-import { cardDefaultProps, createExperience, handleExperienceLoadOptions, handleSkillsLoadOptions, INITIAL_VALUES, statusOptions, typeOptions } from './CreateExperienceForm.config';
+import { cardDefaultProps, createExperience, INITIAL_VALUES, statusOptions, typeOptions } from './CreateExperienceForm.config';
 import { useAjax } from '@/hooks/useAjax';
 import FormMultiSelectChip from '@/hooks/Form/inputs/FormMultiSelectChip';
 import texts from './CreateExperienceForm.text';
+import { loadCompaniesOptions, loadSkillsOptions } from '@/helpers/database.helpers';
 
 export default function CreateExperienceForm({ initialValues = {} }: CreateExperienceFormProps): React.ReactElement {
    const { textResources } = useTextResources(texts);
@@ -91,7 +92,7 @@ export default function CreateExperienceForm({ initialValues = {} }: CreateExper
                   <FormSelect
                      fieldName="company_id"
                      label={textResources.getText('CreateExperienceForm.company_id.label')}
-                     loadOptions={() => handleExperienceLoadOptions(ajax, textResources)}
+                     loadOptions={() => loadCompaniesOptions(ajax, textResources)}
                      disableNone
                   />
                </Card>
@@ -101,7 +102,7 @@ export default function CreateExperienceForm({ initialValues = {} }: CreateExper
                      fieldName="skills"
                      label={textResources.getText('CreateExperienceForm.skills.label')}
                      placeholder={textResources.getText('CreateExperienceForm.skills.placeholder')}
-                     loadOptions={() => handleSkillsLoadOptions(ajax, textResources)}
+                     loadOptions={() => loadSkillsOptions(ajax, textResources)}
                   />
                </Card>
 

--- a/src/components/forms/experiences/EditExperienceDetails/EditExperienceDetails.tsx
+++ b/src/components/forms/experiences/EditExperienceDetails/EditExperienceDetails.tsx
@@ -1,13 +1,13 @@
 import { Form, FormInput } from '@/hooks';
 import FormButtonSelect from '@/hooks/Form/inputs/FormButtonSelect';
 import FormDatePicker from '@/hooks/Form/inputs/FormDatePicker';
-import { handleExperienceLoadOptions, typeOptions } from '../CreateExperienceForm/CreateExperienceForm.config';
+import { typeOptions } from '../CreateExperienceForm/CreateExperienceForm.config';
 import FormSelect from '@/hooks/Form/inputs/FormSelect';
 import { useAjax } from '@/hooks/useAjax';
 import { useTextResources } from '@/services/TextResources/TextResourcesProvider';
 import { useExperienceDetails } from '@/components/content/admin/experience/ExperienceDetailsContent/ExperienceDetailsContext';
 import { ExperienceData } from '@/types/database.types';
-import { handleExperienceUpdate } from '@/helpers/database.helpers';
+import { handleExperienceUpdate, loadCompaniesOptions } from '@/helpers/database.helpers';
 import texts from './EditExperienceDetails.text';
 
 export default function EditExperienceDetails() {
@@ -31,7 +31,7 @@ export default function EditExperienceDetails() {
          <FormSelect
             fieldName="company_id"
             label={textResources.getText('EditExperienceDetails.company.label')}
-            loadOptions={() => handleExperienceLoadOptions(ajax, textResources)}
+            loadOptions={() => loadCompaniesOptions(ajax, textResources)}
          />
          <FormButtonSelect
             fieldName="type"

--- a/src/components/forms/experiences/EditExperienceSkills/EditExperienceSkills.tsx
+++ b/src/components/forms/experiences/EditExperienceSkills/EditExperienceSkills.tsx
@@ -1,11 +1,10 @@
 import { useExperienceDetails } from '@/components/content/admin/experience/ExperienceDetailsContent/ExperienceDetailsContext';
 import { Form } from '@/hooks';
 import FormMultiSelectChip from '@/hooks/Form/inputs/FormMultiSelectChip';
-import { handleSkillsLoadOptions } from '../CreateExperienceForm/CreateExperienceForm.config';
 import { useAjax } from '@/hooks/useAjax';
 import { useTextResources } from '@/services/TextResources/TextResourcesProvider';
 import { ExperienceData } from '@/types/database.types';
-import { handleExperienceUpdate } from '@/helpers/database.helpers';
+import { handleExperienceUpdate, loadSkillsOptions } from '@/helpers/database.helpers';
 import texts from './EditExperienceSkills.text';
 
 export default function EditExperienceSkills() {
@@ -25,7 +24,7 @@ export default function EditExperienceSkills() {
          <FormMultiSelectChip
             id="edit-experience-skills"
             fieldName="skills"
-            loadOptions={() => handleSkillsLoadOptions(ajax, textResources)}
+            loadOptions={() => loadSkillsOptions(ajax, textResources)}
          />
       </Form>
    );

--- a/src/helpers/database.helpers.ts
+++ b/src/helpers/database.helpers.ts
@@ -1,5 +1,7 @@
+import { FormCheckboxOption, FormSelectOption } from "@/hooks/Form/Form.types";
+import { TextResources } from "@/services";
 import Ajax from "@/services/Ajax/Ajax";
-import { ExperienceData } from "@/types/database.types";
+import { CompanyData, ExperienceData, SkillData } from "@/types/database.types";
 
 export const handleExperienceUpdate = async (ajax: Ajax, experience: ExperienceData, values: Partial<ExperienceData>) => {
    if (!values || !Object.keys(values).length) {
@@ -23,3 +25,56 @@ export const handleExperienceUpdate = async (ajax: Ajax, experience: ExperienceD
       throw error;
    }
 };
+
+export async function loadSkillsOptions(ajax: Ajax, textResources: TextResources): Promise<FormSelectOption[]> {
+   const { success, data, message } = await ajax.get<SkillData[]>('/skill/query', { params: { language_set: textResources.currentLanguage } });
+
+   if (!success) {
+      console.error('Failed to load skills:', message);
+      return [];
+   }
+
+   return data.map((skill: SkillData) => ({
+      value: Number(skill.id),
+      label: String(skill.name),
+   }));
+}
+
+export async function loadCompaniesOptions(ajax: Ajax, textResources: TextResources): Promise<FormSelectOption[]> {
+   const { success, data, message } = await ajax.get<CompanyData[]>('/company/query', {
+      params: { language_set: textResources.currentLanguage }
+   });
+
+   if (!success) {
+      console.error('Failed to load companies:', message);
+      return [];
+   }
+
+   return data.map((company: CompanyData) => ({
+      value: Number(company.id),
+      label: String(company.company_name)
+   }));
+}
+
+export async function loadExperiencesListOptions(ajax: Ajax, language_set: string): Promise<FormCheckboxOption[]> {
+   const maxSecondaryLength = 100;
+
+   try {
+      const { data = [] } = await ajax.get<ExperienceData[]>('/experience/query', { params: { language_set } });
+
+      if (!Array.isArray(data)) {
+         throw new Error("Failed to load experiences");
+      }
+
+      return data.map((item: ExperienceData) => ({
+         id: item.id,
+         primary: `${item.company?.company_name} (${item.position})`,
+         secondary: item.title,
+         avatarUrl: item.company?.logo_url
+      }));
+   } catch (error) {
+      console.error("Error loading experiences list options:", error);
+      throw error;
+   }
+
+}

--- a/src/hooks/Form/Form.scss
+++ b/src/hooks/Form/Form.scss
@@ -127,4 +127,57 @@
          }
       }
    }
+
+   .FormCheckboxList {
+      .selected-options {
+         display: flex;
+         flex-wrap: wrap;
+         column-gap: 0.8rem;
+
+         .option-item {
+            background-color: $background-dark;
+            border-bottom: 3px solid $tertiary;
+            cursor: pointer;
+            -webkit-user-select: none;
+            user-select: none;
+
+            .primary-text {
+               color: $text;
+            }
+
+            .secondary-text {
+               color: $text-soft;
+               font-size: 0.9rem;
+            }
+         }
+
+         .options-list {
+            max-height: 30rem;
+            overflow-y: auto;
+         }
+      }
+
+      .MuiListItem-root {
+         background-color: $background-dark;
+         border-radius: $radius-s;
+         border-left: 3px solid $primary;
+
+         &:not(:last-child) {
+            margin-bottom: 0.5rem;
+         }
+
+         .MuiAvatar-circular {
+            background-color: $white;
+            object-fit: contain;
+         }
+
+         .MuiListItemText-secondary {
+            color: $text-soft;
+         }
+
+         .MuiSvgIcon-root {
+            color: $text-soft;
+         }
+      }
+   }
 }

--- a/src/hooks/Form/Form.types.ts
+++ b/src/hooks/Form/Form.types.ts
@@ -8,6 +8,7 @@ export interface ErrorTileProps {
 
 export type FormValues = Record<string, unknown>;
 export type FormErrors = Record<string, string | undefined>;
+export type FormValue = string | number | boolean | (string | number | boolean)[];
 
 export interface FormResponseError {
   error?: true;
@@ -46,7 +47,7 @@ export interface FormBaseInputProps {
   fieldName?: string;
   label?: string;
   parseInput?: (value: string | number) => unknown;
-  onChange?: (value: string | number | (string | number)[]) => void;
+  onChange?: (value: FormValue) => void;
 }
 
 export interface FormInputProps extends FormBaseInputProps {
@@ -94,4 +95,21 @@ export interface FormSubmitProps {
 
 export interface FormMultiSelectChipProps extends FormSelectProps {
   [key: string]: unknown;
+}
+
+export interface FormCheckSwitchProps extends FormBaseInputProps {
+  checked?: boolean;
+}
+
+export interface FormCheckboxListProps extends FormBaseInputProps {
+  className?: string | string[];
+  options?: FormCheckboxOption[];
+  loadOptions?: () => Promise<FormCheckboxOption[]>;
+}
+
+export interface FormCheckboxOption {
+  id: number;
+  primary: string;
+  secondary?: string;
+  avatarUrl?: string;
 }

--- a/src/hooks/Form/inputs/FormCheckSwitch.tsx
+++ b/src/hooks/Form/inputs/FormCheckSwitch.tsx
@@ -1,0 +1,33 @@
+import { FormControlLabel, Switch } from "@mui/material";
+import { FormCheckSwitchProps } from "../Form.types";
+import { useForm } from "../Form";
+
+export default function FormCheckSwitch({ fieldName, label, onChange }: FormCheckSwitchProps) {
+   const { getValue, setFieldValue } = useForm();
+
+   if (!fieldName) {
+      console.error("FormCheckSwitch requires a fieldName prop.");
+      return null;
+   }
+
+   const handleChange = () => {
+      const newValue = !Boolean(getValue(fieldName));
+
+      setFieldValue(fieldName, newValue);
+      if (onChange) {
+         onChange(newValue);
+      }
+   }
+
+   return (
+      <FormControlLabel
+         label={label}
+         control={
+            <Switch
+               checked={Boolean(getValue(fieldName))}
+               onChange={handleChange}
+            />
+         }
+      />
+   );
+}

--- a/src/hooks/Form/inputs/FormCheckboxList.tsx
+++ b/src/hooks/Form/inputs/FormCheckboxList.tsx
@@ -1,0 +1,103 @@
+import { Avatar, Checkbox, List, ListItem, ListItemAvatar, ListItemButton, ListItemText } from '@mui/material';
+import { useForm } from '../Form';
+import { FormCheckboxListProps } from '../Form.types';
+import { useEffect, useState } from 'react';
+import { parseCSS } from '@/helpers/parse.helpers';
+import WidgetHeader from '@/components/headers/WidgetHeader/WidgetHeader';
+import { Card } from '@/components/common';
+
+export default function FormCheckboxList({ className, label = 'Select one option', fieldName, options = [], loadOptions }: FormCheckboxListProps) {
+   const { getValue, setFieldValue } = useForm();
+   const [ optionState, setOptionState ] = useState(options);
+
+   const CSS = parseCSS(className, [
+      'FormCheckboxList'
+   ]);
+
+   if (!fieldName) {
+      console.error("FormCheckboxList: fieldName is required");
+      return null;
+   }
+
+   const values = getValue(fieldName) as number[] || [];
+   const isChecked = (id: number) => values.includes(id);
+
+   const handleChange = ({ target: { checked } }: React.ChangeEvent<HTMLInputElement>, id: number) => {
+      if (checked && !isChecked(id)) {
+         setFieldValue(fieldName, [ ...values, id ]);
+      } else {
+         setFieldValue(fieldName, values.filter((value) => value !== id));
+      }
+   }
+
+   const handleRemoveSelection = (id: number) => {
+      setFieldValue(fieldName, values.filter((value) => value !== id));
+   };
+
+   useEffect(() => {
+      if (!loadOptions) return;
+
+      loadOptions().then((loadedOptions) => {
+         setOptionState(loadedOptions);
+      }).catch((error) => {
+         console.error("Error loading options for FormCheckboxList:", error);
+      });
+   }, []);
+
+   return (
+      <div className={CSS}>
+         <WidgetHeader title={label} />
+
+         <div className="selected-options">
+            {optionState.filter(option => isChecked(option.id)).map(option => (
+               <Card
+                  key={option.id}
+                  className="option-item"
+                  padding="m"
+                  radius="s"
+                  elevation="none"
+                  onClick={() => handleRemoveSelection(option.id)}
+               >
+                  <p className="primary-text">{option.primary}</p>
+                  <p className="secondary-text">{option.secondary}</p>
+               </Card>
+            ))}
+         </div>
+
+         <List className="options-list" dense>
+            {optionState.map((value) => {
+               const labelId = `form-checkbox-list-${value.id}`;
+
+               return (
+                  <ListItem
+                     key={value.id}
+                     disablePadding
+                     secondaryAction={
+                        <Checkbox
+                           edge="end"
+                           onChange={(ev) => handleChange(ev, value.id)}
+                           checked={isChecked(value.id)}
+                        />
+                     }
+                  >
+                     <ListItemButton>
+                        <ListItemAvatar>
+                           <Avatar
+                              alt={`Avatar ${value.primary}`}
+                              src={value.avatarUrl}
+                           />
+                        </ListItemAvatar>
+
+                        <ListItemText
+                           id={labelId}
+                           primary={value.primary}
+                           secondary={value.secondary}
+                        />
+                     </ListItemButton>
+                  </ListItem>
+               );
+            })}
+         </List>
+      </div>
+   );
+}

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -58,3 +58,20 @@ export interface SkillSetData extends BasicData {
    user_id: number;
    languageSets: SkillData[];
 }
+
+export interface CVData extends CVSetData {
+   title: string;
+   is_master: boolean;
+   notes?: string;
+   cv_experiences?: ExperienceData[];
+   cv_skills?: SkillData[];
+   languageSets: CVSetData[];
+}
+
+export interface CVSetData extends BasicData {
+   language_set: string;
+   summary?: string;
+   professional_title?: string;
+   user_id: number;
+   cv_id: number;
+}


### PR DESCRIPTION
## [FRD-110] Description
This pull request introduces a new "Create Curriculum" feature and refactors existing code to improve modularity and reusability. The most important changes include the addition of new components and utilities for the curriculum creation flow, updates to the `Card` component to support click events, and refactoring of helper functions for loading options in forms.

### New "Create Curriculum" Feature:

* **New curriculum creation page and components**:
  - Added `CurriculumCreatePage` as the entry point for the curriculum creation feature, which detects the user's locale and renders the `CreateCurriculumContent` component (`src/app/admin/curriculum/create/page.tsx`, [src/app/admin/curriculum/create/page.tsxR1-R13](diffhunk://#diff-3aa97a35031c0d6c5cb970c4e367e18f869f41038340e034456aed917fab02d1R1-R13)).
  - Introduced `CreateCurriculumContent` to handle the layout and localization of the curriculum creation form (`src/components/content/admin/curriculum/CreateCurriculumContent/CreateCurriculumContent.tsx`, [src/components/content/admin/curriculum/CreateCurriculumContent/CreateCurriculumContent.tsxR1-R24](diffhunk://#diff-87588187bf72923de6ab9506f2ed78456687f9ceb664ea5b9215272aaf100c8bR1-R24)).
  - Added a comprehensive `CreateCurriculumForm` component to handle form inputs, submission, and validation for creating a curriculum (`src/components/forms/curriculums/CreateCurriculumForm/CreateCurriculumForm.tsx`, [src/components/forms/curriculums/CreateCurriculumForm/CreateCurriculumForm.tsxR1-R113](diffhunk://#diff-ee243cb22f4536102aa28e727c163665532398c0575c2d9b074717f6782a3d8cR1-R113)).

* **Text resources for localization**:
  - Added localized text resources for the curriculum creation page and form, supporting both English and Portuguese (`CreateCurriculumContent.text.ts`, [[1]](diffhunk://#diff-123df33b1dbf8625103a96cffdc97d6b54d9491d316d2ec575d1314827f010e6R1-R11); `CreateCurriculumForm.text.ts`, [[2]](diffhunk://#diff-eb34fb1e03ba9402d0c1a5c21fa80bee30e9830dfb7cdba12eb26ca2d6001327R1-R41).

### Updates to Common Components:

* **Enhancement to `Card` component**:
  - Added an `onClick` prop to the `Card` component to support click events (`src/components/common/Card/Card.tsx`, [[1]](diffhunk://#diff-b2222ae6bd474e6da6aced49cc5715f7939ed77c72de248442ff34f5165a07cdR16) [[2]](diffhunk://#diff-b2222ae6bd474e6da6aced49cc5715f7939ed77c72de248442ff34f5165a07cdL28-R29); `Card.types.ts`, [[3]](diffhunk://#diff-75a890a5b58028cbbd6c9ee5aa99b9f85baaaa5d8fd2a3714f7217c34288cad3R16).

### Refactoring for Reusability:

* **Centralized helper functions**:
  - Moved reusable functions for loading skills, companies, and experiences options into `src/helpers/database.helpers.ts` to improve modularity (`[[1]](diffhunk://#diff-0716a1c2a7aabef86cfe340116f382528a8e28774b3824945b7cf6d133021133R1-R4)`, [[2]](diffhunk://#diff-0716a1c2a7aabef86cfe340116f382528a8e28774b3824945b7cf6d133021133R28-R80).

* **Refactored forms to use centralized helpers**:
  - Updated forms such as `CreateExperienceForm`, `EditExperienceDetails`, and `EditExperienceSkills` to use the new helper functions for loading options (`[[1]](diffhunk://#diff-2dff4576d681e8ed287902768f4adc8810523e463c11426eba903126146b4894L15-R19)`, [[2]](diffhunk://#diff-2dff4576d681e8ed287902768f4adc8810523e463c11426eba903126146b4894L94-R95) [[3]](diffhunk://#diff-2dff4576d681e8ed287902768f4adc8810523e463c11426eba903126146b4894L104-R105) [[4]](diffhunk://#diff-6b517b05f515286dba08c4f5acd1246c7e43616e04efa6e4c8779d6128f1fe2aL4-R10) [[5]](diffhunk://#diff-6b517b05f515286dba08c4f5acd1246c7e43616e04efa6e4c8779d6128f1fe2aL34-R34) [[6]](diffhunk://#diff-48410a701720353840c7a36f4e2411d18615f30c49ddae767e45f87b98e9721eL4-R7) [[7]](diffhunk://#diff-48410a701720353840c7a36f4e2411d18615f30c49ddae767e45f87b98e9721eL28-R27).

These changes collectively enhance the user experience for creating curricula, improve code maintainability, and align with best practices for modular design.

[FRD-110]: https://feliperamosdev.atlassian.net/browse/FRD-110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ