### PR TITLE
[FRD-123] Responsiveness issues with CV tile

### DIFF
--- a/src/components/tiles/CVTile/CVTile.module.scss
+++ b/src/components/tiles/CVTile/CVTile.module.scss
@@ -1,14 +1,28 @@
 @use '@/style/variables' as *;
 
 .CVTile {
-   display: flex;
-   gap: 1rem;
    cursor: pointer;
    transition: all 100ms;
    border-bottom: 3px solid $primary;
 
    &:hover {
       background-color: $background-light;
+   }
+
+   .cardHeader {
+      display: flex;
+      gap: 1rem;
+   }
+
+   .cardBody {
+      margin-top: 1rem;
+      margin-bottom: 0;
+      background-color: $background-dark;
+
+      p {
+         color: $text-soft;
+         font-size: 0.9rem;
+      }
    }
 
    .noCV {

--- a/src/components/tiles/CVTile/CVTile.tsx
+++ b/src/components/tiles/CVTile/CVTile.tsx
@@ -1,7 +1,7 @@
 import { Card } from '@/components/common';
 import { CVTileProps } from './CVTile.types';
 import styles from './CVTile.module.scss';
-import { Folder } from '@mui/icons-material';
+import { InsertDriveFile } from '@mui/icons-material';
 import { parseCSS } from '@/helpers/parse.helpers';
 
 export default function CVTile({ className, cv, onClick = () => {} }: CVTileProps): React.ReactNode {
@@ -10,23 +10,35 @@ export default function CVTile({ className, cv, onClick = () => {} }: CVTileProp
       styles.CVTile
    ]);
 
+   const summary = cv?.summary && cv.summary.length > 200 ? (
+      `${cv.summary.substring(0, 200)}...`
+   ) : (
+      cv?.summary || ''
+   )
+
    if (!cv || cv === null) {
       return null;
    }
 
    return (
       <Card className={CSS} padding="s" onClick={() => onClick(cv.id)}>
-         <div className={styles.cvIconWrap}>
-            <Folder
-               className={styles.cvIcon}
-               fontSize="large"
-            />
+         <div className={styles.cardHeader}>
+            <div className={styles.cvIconWrap}>
+               <InsertDriveFile
+                  className={styles.cvIcon}
+                  fontSize="large"
+               />
+            </div>
+            
+            <div className={styles.cvDetails}>
+               <h3>{cv.title}</h3>
+               <p className={styles.subTitle}>{cv.job_title}</p>
+            </div>
          </div>
-         
-         <div className={styles.cvDetails}>
-            <h3>{cv.title}</h3>
-            <p>{cv.summary}</p>
-         </div>
+
+         <Card className={styles.cardBody} elevation="none">
+            <p>{summary}</p>
+         </Card>
       </Card>
    );
 }

--- a/src/components/widgets/CVsWidget/CVsWidget.module.scss
+++ b/src/components/widgets/CVsWidget/CVsWidget.module.scss
@@ -21,9 +21,19 @@
       gap: 1rem;
 
       .listItem {
-         flex: calc(33.33% - 1rem);
-         max-width: calc(33.33% - 0.5rem);
          margin-bottom: 0;
+         flex: 100%;
+         max-width: 100%;
+
+         @media screen and (min-width: $screen-m) {
+            flex: calc(50% - 1rem);
+            max-width: calc(50% - 0.5rem);
+         }
+
+         @media screen and (min-width: $screen-l) {
+            flex: calc(33.33% - 1rem);
+            max-width: calc(33.33% - 0.5rem);
+         }
       }
    }
 }


### PR DESCRIPTION
## [FRD-123] Description
This pull request refactors the `CVTile` component to improve its structure, styling, and functionality. Key changes include restructuring the component's layout, updating its styles for better responsiveness, and enhancing the display of CV summaries.

### Updates to component structure and functionality:

* `src/components/tiles/CVTile/CVTile.tsx`: 
  - Replaced the `Folder` icon with `InsertDriveFile` for better semantic alignment.
  - Added logic to truncate CV summaries longer than 200 characters, appending ellipses when necessary.
  - Restructured the component layout by introducing `cardHeader` and `cardBody` sections, separating the title, job title, and summary for improved readability.

### Styling improvements:

* `src/components/tiles/CVTile/CVTile.module.scss`: 
  - Moved the `display: flex` and `gap` properties from the parent `.CVTile` class to the newly added `.cardHeader` class for better layout control. [[1]](diffhunk://#diff-37081d588ad9707ed5dcf5cd14b45f350379105a7db9e61ca524c52e2e8d48d3L4-L5) [[2]](diffhunk://#diff-37081d588ad9707ed5dcf5cd14b45f350379105a7db9e61ca524c52e2e8d48d3R12-R27)
  - Added a `.cardBody` class with distinct styles for the summary section, including text color and font size adjustments.

* `src/components/widgets/CVsWidget/CVsWidget.module.scss`: 
  - Updated the `.listItem` class to improve responsiveness, adjusting the flex and max-width properties for different screen sizes.

[FRD-123]: https://feliperamosdev.atlassian.net/browse/FRD-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ