### PR TITLE
[FRD-120] Delete Feature

### DIFF
--- a/src/components/content/admin/company/CompanyDetailsContent/CompanyDetailsContent.text.ts
+++ b/src/components/content/admin/company/CompanyDetailsContent/CompanyDetailsContent.text.ts
@@ -63,4 +63,11 @@ textResources.create('CompanyDetailsContent.label.id', 'ID:', 'pt');
 textResources.create('CompanyDetailsContent.label.createdAt', 'Created At:');
 textResources.create('CompanyDetailsContent.label.createdAt', 'Criado em:', 'pt');
 
+// Delete 
+textResources.create('CompanyDetailsContent.button.delete', 'Delete Company');
+textResources.create('CompanyDetailsContent.button.delete', 'Excluir Empresa', 'pt');
+
+textResources.create('CompanyDetailsContent.confirmDelete', 'Are you sure you want to delete this company?');
+textResources.create('CompanyDetailsContent.confirmDelete', 'Tem certeza de que deseja excluir esta empresa?', 'pt');
+
 export default textResources;

--- a/src/components/content/admin/company/CompanyDetailsContent/slices/CompanyDetailsSidebar.tsx
+++ b/src/components/content/admin/company/CompanyDetailsContent/slices/CompanyDetailsSidebar.tsx
@@ -1,14 +1,43 @@
 import { Card } from '@/components/common';
 import DataContainer from '@/components/layout/DataContainer/DataContainer';
-import { Fragment } from 'react';
+import { Fragment, useState } from 'react';
 import { useCompanyDetails } from '../CompanyDetailsContext';
 import { useTextResources } from '@/services/TextResources/TextResourcesProvider';
 import texts from '../CompanyDetailsContent.text';
+import { Form, FormSubmit } from '@/hooks';
+import { useAjax } from '@/hooks/useAjax';
+import { useRouter } from 'next/navigation';
 
 
 export default function CompanyDetailsSidebar(): React.ReactElement {
+   const [ deleteLoading, setDeleteLoading ] = useState<boolean>(false);
    const company = useCompanyDetails();
    const { textResources } = useTextResources(texts);
+   const ajax = useAjax();
+   const router = useRouter();
+
+   const handleDelete = async () => {
+      const confirmed = confirm(textResources.getText('CompanyDetailsContent.confirmDelete'));
+
+      if (!confirmed) {
+         return { success: true };
+      }
+
+      try {
+         setDeleteLoading(true);
+         const deleted = await ajax.post('/company/delete', { companyId: company?.id });
+         if (!deleted.success) {
+            return deleted;
+         }
+
+         router.push('/admin');
+         return deleted;
+      } catch (error) {
+         throw error;
+      } finally {
+         setDeleteLoading(false);
+      }
+   }
 
    return (
       <Fragment>
@@ -21,6 +50,16 @@ export default function CompanyDetailsSidebar(): React.ReactElement {
                <label>{textResources.getText('CompanyDetailsContent.label.createdAt')}</label>
                <span>{new Date(company?.created_at).toLocaleString()}</span>
             </DataContainer>
+         </Card>
+
+         <Card padding="l">
+            <Form hideSubmit onSubmit={handleDelete}>
+               <FormSubmit
+                  color="error"
+                  label={textResources.getText('CompanyDetailsContent.button.delete')}
+                  loading={deleteLoading}
+               />
+            </Form>
          </Card>
       </Fragment>
    );

--- a/src/components/content/admin/curriculum/CVDetailsContent/CVDetailsContent.text.ts
+++ b/src/components/content/admin/curriculum/CVDetailsContent/CVDetailsContent.text.ts
@@ -56,11 +56,17 @@ textResources.create('CVDetailsSidebar.skills.editButton', 'Editar Habilidades d
 textResources.create('CVDetailsSidebar.is_master.text', 'MASTER CV');
 textResources.create('CVDetailsSidebar.is_master.text', 'CV PRINCIPAL', 'pt');
 
+textResources.create('CVDetailsSidebar.confirmDelete', 'Are you sure you want to delete this CV?');
+textResources.create('CVDetailsSidebar.confirmDelete', 'Tem certeza de que deseja excluir este CV?', 'pt');
+
 // CVExperiences
 textResources.create('CVExperiences.widgetTitle', 'CV Experiences');
 textResources.create('CVExperiences.widgetTitle', 'Experiências do CV', 'pt');
 
 textResources.create('CVExperiences.editButton', 'Edit Curriculum Experiences');
 textResources.create('CVExperiences.editButton', 'Editar Experiências do Curriculum', 'pt');
+
+textResources.create('CVDetailsSidebar.button.delete', 'Delete Curriculum');
+textResources.create('CVDetailsSidebar.button.delete', 'Excluir Curriculum', 'pt');
 
 export default textResources;

--- a/src/components/content/admin/experience/ExperienceDetailsContent/ExperienceDetailsContent.text.ts
+++ b/src/components/content/admin/experience/ExperienceDetailsContent/ExperienceDetailsContent.text.ts
@@ -20,6 +20,8 @@ textResources.create('ExperienceDetailsSection.field.title', 'Título:', 'pt');
 
 textResources.create('ExperienceDetailsSection.field.company', 'Company:');
 textResources.create('ExperienceDetailsSection.field.company', 'Empresa:', 'pt');
+textResources.create('ExperienceDetailsSection.noCompany', 'No company associated');
+textResources.create('ExperienceDetailsSection.noCompany', 'Nenhuma empresa associada', 'pt');
 
 textResources.create('ExperienceDetailsSection.field.type', 'Type:');
 textResources.create('ExperienceDetailsSection.field.type', 'Tipo:', 'pt');
@@ -73,6 +75,13 @@ textResources.create('ExperienceSetsSection.field.responsibilities', 'Responsabi
 
 textResources.create('ExperienceSetsSection.field.responsibilities.noResponsibilities', 'No responsibilities available.');
 textResources.create('ExperienceSetsSection.field.responsibilities.noResponsibilities', 'Nenhuma responsabilidade disponível.', 'pt');
+
+// Delete
+textResources.create('ExperienceDetailsSidebar.button.delete', 'Delete Experience');
+textResources.create('ExperienceDetailsSidebar.button.delete', 'Excluir Experiência', 'pt');
+
+textResources.create('ExperienceDetailsSidebar.confirmDelete', 'Are you sure you want to delete this experience?');
+textResources.create('ExperienceDetailsSidebar.confirmDelete', 'Tem certeza de que deseja excluir esta experiência?', 'pt');
 
 export default textResources;
 

--- a/src/components/content/admin/experience/ExperienceDetailsContent/common/ExperienceDetailsSection.tsx
+++ b/src/components/content/admin/experience/ExperienceDetailsContent/common/ExperienceDetailsSection.tsx
@@ -38,9 +38,13 @@ export default function ExperienceDetailsSection() {
             <Fragment>
                <DataContainer>
                   <label>{textResources.getText('ExperienceDetailsSection.field.company')}</label>
-                  <Link href={`/admin/company/${experience.company?.id}`}>
-                     {experience.company?.company_name}
-                  </Link>
+                  {experience.company?.company_name ? (
+                     <Link href={`/admin/company/${experience.company?.id}`}>
+                        {experience.company?.company_name}
+                     </Link>
+                  ) : (
+                     <span>{textResources.getText('ExperienceDetailsSection.noCompany')}</span>
+                  )}
                </DataContainer>
                <DataContainer>
                   <label>{textResources.getText('ExperienceDetailsSection.field.type')}</label>

--- a/src/components/content/admin/experience/ExperienceDetailsContent/common/ExperienceDetailsSidebar.tsx
+++ b/src/components/content/admin/experience/ExperienceDetailsContent/common/ExperienceDetailsSidebar.tsx
@@ -10,6 +10,10 @@ import texts from '../ExperienceDetailsContent.text';
 import DataContainer from '@/components/layout/DataContainer/DataContainer';
 import styles from '../ExperienceDetailsContent.module.scss';
 import { EditButtons } from '@/components/buttons';
+import { Form, FormSubmit } from '@/hooks';
+import { useAjax } from '@/hooks/useAjax';
+import { useRouter } from 'next/navigation';
+import { ErrorSharp } from '@mui/icons-material';
 
 function SectionCard({ children }: { children: React.ReactNode }) {
    return <Card padding="l">{children}</Card>;
@@ -17,8 +21,35 @@ function SectionCard({ children }: { children: React.ReactNode }) {
 
 export default function ExperienceDetailsSidebar(): React.ReactElement {
    const [editSkills, setEditSkills] = useState<boolean>(false);
+   const [deleteLoading, setDeleteLoading] = useState<boolean>(false);
    const experience = useExperienceDetails();
    const { textResources } = useTextResources(texts);
+   const ajax = useAjax();
+   const router = useRouter();
+
+   const handleDelete = async () => {
+      const confirmMessage = textResources.getText('ExperienceDetailsSidebar.confirmDelete');
+      const confirmed = confirm(confirmMessage);
+
+      if (!confirmed) {
+         return { success: true };
+      }
+
+      try {
+         setDeleteLoading(true);
+         const deleted = await ajax.post('/experience/delete', { experienceId: experience?.id });
+         if (!deleted.success) {
+            return deleted;
+         }
+
+         router.push('/admin');
+         return deleted;
+      } catch (error) {
+         throw error;
+      } finally {
+         setDeleteLoading(false);
+      }
+   }
 
    return (
       <Fragment>
@@ -59,6 +90,16 @@ export default function ExperienceDetailsSidebar(): React.ReactElement {
                   )}
                </DataContainer>
             )}
+         </SectionCard>
+
+         <SectionCard>
+            <Form hideSubmit onSubmit={handleDelete}>
+               <FormSubmit
+                  color="error"
+                  loading={deleteLoading}
+                  label={textResources.getText('ExperienceDetailsSidebar.button.delete')}
+               />
+            </Form>
          </SectionCard>
       </Fragment>
    );

--- a/src/components/content/admin/experience/ExperienceDetailsContent/common/ExperienceDetailsSidebar.tsx
+++ b/src/components/content/admin/experience/ExperienceDetailsContent/common/ExperienceDetailsSidebar.tsx
@@ -13,7 +13,6 @@ import { EditButtons } from '@/components/buttons';
 import { Form, FormSubmit } from '@/hooks';
 import { useAjax } from '@/hooks/useAjax';
 import { useRouter } from 'next/navigation';
-import { ErrorSharp } from '@mui/icons-material';
 
 function SectionCard({ children }: { children: React.ReactNode }) {
    return <Card padding="l">{children}</Card>;

--- a/src/components/content/admin/skill/SkillDetailsContent/SkillDetailsContent.text.ts
+++ b/src/components/content/admin/skill/SkillDetailsContent/SkillDetailsContent.text.ts
@@ -41,8 +41,14 @@ textResources.create('SkillDetailsContent.skillSets.unknownSet', 'Unknown Langua
 textResources.create('SkillDetailsContent.skillSets.unknownSet', 'Campos de Idiomas Desconhecido', 'pt');
 
 // SkillDetailsSidebar
-textResources.create('SkillDetailsContent.skillSidebar.id', 'ID:');
-textResources.create('SkillDetailsContent.skillSidebar.id', 'ID:', 'pt');
+textResources.create('SkillDetailsSidebar.skillSidebar.id', 'ID:');
+textResources.create('SkillDetailsSidebar.skillSidebar.id', 'ID:', 'pt');
+
+textResources.create('SkillDetailsSidebar.button.delete', 'Delete Skill');
+textResources.create('SkillDetailsSidebar.button.delete', 'Excluir Habilidade', 'pt');
+
+textResources.create('SkillDetailsSidebar.confirmDelete', 'Are you sure you want to delete this skill?');
+textResources.create('SkillDetailsSidebar.confirmDelete', 'Você tem certeza de que deseja excluir esta habilidade?', 'pt');
 
 export default textResources;
 

--- a/src/components/content/admin/skill/SkillDetailsContent/subcomponents/SkillDetailsSidebar.tsx
+++ b/src/components/content/admin/skill/SkillDetailsContent/subcomponents/SkillDetailsSidebar.tsx
@@ -1,21 +1,61 @@
 import { Card } from '@/components/common';
 import DataContainer from '@/components/layout/DataContainer/DataContainer';
-import { Fragment } from 'react';
+import { Fragment, useState } from 'react';
 import { useSkillDetails } from '../SkillDetailsContext';
 import { useTextResources } from '@/services/TextResources/TextResourcesProvider';
 import texts from '../SkillDetailsContent.text';
+import { Form, FormSubmit } from '@/hooks';
+import { useRouter } from 'next/navigation';
+import { useAjax } from '@/hooks/useAjax';
 
 export default function SkillDetailsSidebar(): React.ReactElement {
+   const [deleteLoading, setDeleteLoading] = useState<boolean>(false);
    const skill = useSkillDetails();
    const { textResources } = useTextResources(texts);
+   const router = useRouter();
+   const ajax = useAjax();
+
+   const handleDelete = async () => {
+      const confirmMessage = textResources.getText('SkillDetailsSidebar.confirmDelete');
+      const confirmed = confirm(confirmMessage);
+
+      if (!confirmed) {
+         return { success: true };
+      }
+
+      try {
+         setDeleteLoading(true);
+         const deleted = await ajax.post('/skill/delete', { skillId: skill?.id });
+         if (!deleted.success) {
+            return deleted;
+         }
+
+         router.push('/admin');
+         return deleted;
+      } catch (error) {
+         throw error;
+      } finally {
+         setDeleteLoading(false);
+      }
+   }
 
    return (
       <Fragment>
          <Card padding="l">
             <DataContainer>
-               <label>{textResources.getText('SkillDetailsContent.skillSidebar.id')}</label>
+               <label>{textResources.getText('SkillDetailsSidebar.skillSidebar.id')}</label>
                <span>{skill.id}</span>
             </DataContainer>
+         </Card>
+
+         <Card padding="l">
+            <Form hideSubmit onSubmit={handleDelete}>
+               <FormSubmit
+                  color="error"
+                  label={textResources.getText('SkillDetailsSidebar.button.delete')}
+                  loading={deleteLoading}
+               />
+            </Form>
          </Card>
       </Fragment>
    );

--- a/src/hooks/Form/Form.scss
+++ b/src/hooks/Form/Form.scss
@@ -99,11 +99,6 @@
       }
    }
 
-   .FormSubmit {
-      background-color: $tertiary;
-      color: $text-contrast;
-   }
-
    .FormMultiSelectChip {
       width: 100%;
       margin-bottom: 0.5rem;

--- a/src/hooks/Form/Form.types.ts
+++ b/src/hooks/Form/Form.types.ts
@@ -93,6 +93,7 @@ export interface FormSubmitProps {
   fullWidth?: boolean;
   loading?: boolean;
   disabled?: boolean;
+  [key: string]: unknown;
 }
 
 export interface FormMultiSelectChipProps extends FormSelectProps {

--- a/src/theme/defaultTheme.ts
+++ b/src/theme/defaultTheme.ts
@@ -5,7 +5,8 @@ export default createTheme({
       primary: { main: '#006C67' },
       secondary: { main: '#0D1B2A' },
       tertiary: { main: '#8FE388' },
-      success: { main: '#8FE388' }
+      success: { main: '#8FE388' },
+      error: { main: '#e74438' },
    },
    components: {
       MuiButton: {


### PR DESCRIPTION
## [FRD-120] Description
This pull request introduces delete functionality to various admin components, allowing users to delete companies, CVs, experiences, and skills. It also includes updates to the text resources for these components and minor UI and theme adjustments.

### New Delete Functionality:

* **Company Details**:
  - Added a delete button and confirmation prompt in `CompanyDetailsSidebar` to allow users to delete a company. Integrated with the backend via an AJAX call and redirects to the admin page upon success. 
  - Updated text resources to include delete button labels and confirmation messages. 

* **CV Details**:
  - Added a delete button and confirmation prompt in `CVDetailsSidebar` for deleting CVs, similar to the company delete functionality. 
  - Updated text resources with delete-related labels and messages. 

* **Experience Details**:
  - Implemented delete functionality in `ExperienceDetailsSidebar`, including a confirmation prompt and backend integration. 
  - Added text resources for delete button labels and confirmation prompts. 

* **Skill Details**:
  - Added a delete button and confirmation prompt in `SkillDetailsSidebar` for removing skills. 
  - Updated text resources for delete-related actions. 

### Text Resource Updates:

* Added new text keys and translations for delete actions across multiple components, ensuring consistency in English and Portuguese.

### UI and Theme Adjustments:

* Added an `error` color to the theme for styling delete buttons.
* Updated `FormSubmit` component to support additional props and removed unused styles.

[FRD-120]: https://feliperamosdev.atlassian.net/browse/FRD-120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ