### PR TITLE
[FRD-115] Load Home from CV

### DIFF
--- a/src/components/content/HomeContent/HomeContent.tsx
+++ b/src/components/content/HomeContent/HomeContent.tsx
@@ -1,18 +1,20 @@
 import { HomeTopBanner } from '@/components/banners';
 import { Experience, Skills } from './sections';
 import ajax from '@/hooks/useAjax';
-import { ExperienceData, SkillData } from '@/types/database.types';
+import { CVData, ExperienceData, SkillData } from '@/types/database.types';
 
 export default async function HomeContent({ language = 'en' }: { language?: string }): Promise<React.ReactElement> {
-   const experiencesData = await ajax.get('/experience/public/user-experiences', { params: { language_set: language } });
-   const skillsData = await ajax.get<SkillData[]>('/skill/public/user-skills', { params: { language_set: language } });
+   const masterCV = await ajax.get<CVData>('/user/master-cv', { params: { language_set: language } });
+   const cvData = masterCV.data as CVData;
 
    return (
       <div className="HomeContent">
          <HomeTopBanner />
 
-         <Skills skills={skillsData.data as SkillData[]} />
-         <Experience experiences={experiencesData.data as ExperienceData[]} />
+         {cvData && (<>
+            <Skills skills={cvData?.cv_skills as SkillData[]} />
+            <Experience experiences={cvData?.cv_experiences as ExperienceData[]} />
+         </>)}
       </div>
    )
 }

--- a/src/components/content/HomeContent/sections/Experience/ExperienceItem.tsx
+++ b/src/components/content/HomeContent/sections/Experience/ExperienceItem.tsx
@@ -9,7 +9,7 @@ import { DateView, Markdown } from '@/components/common';
 export default function ExperienceItem({ experience }: ExperienceItemProps): React.ReactElement {
    const iconButtonDefault = {
       className: 'icon-button',
-      color: 'inherit' as const,
+      color: 'background-dark' as const,
       size: 'medium' as const
    };
 


### PR DESCRIPTION
## [FRD-115] Description
This pull request refactors the data fetching logic in the `HomeContent` component to consolidate API calls into a single endpoint and updates the `ExperienceItem` component's styling for improved consistency. Below are the key changes:

### Data fetching refactor in `HomeContent`:

* Consolidated multiple API calls (`/experience/public/user-experiences` and `/skill/public/user-skills`) into a single call to `/user/master-cv`. Updated the `HomeContent` component to use `CVData` for rendering `Skills` and `Experience` sections. (`[src/components/content/HomeContent/HomeContent.tsxL4-R17](diffhunk://#diff-490b343025ef4ae2a26192e5de01143d06b24d78fa7fa7600d85cd47aca55123L4-R17)`)
* Updated the `import` statement in `HomeContent.tsx` to include the new `CVData` type from `database.types`. (`[src/components/content/HomeContent/HomeContent.tsxL4-R17](diffhunk://#diff-490b343025ef4ae2a26192e5de01143d06b24d78fa7fa7600d85cd47aca55123L4-R17)`)

### Styling update in `ExperienceItem`:

* Changed the `color` property of the `iconButtonDefault` object in `ExperienceItem` from `'inherit'` to `'background-dark'` for improved visual alignment. (`[src/components/content/HomeContent/sections/Experience/ExperienceItem.tsxL12-R12](diffhunk://#diff-5aeb5bf9300060be7444cd9eefe8236f23dd448ab877bf98d9caec0ae1e4cdd7L12-R12)`)