### PR TITLE
[FRD-113] CV PDF Template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ next-env.d.ts
 
 package-lock.json
 .swc
+
+certificates

--- a/src/app/[lang]/curriculum/pdf/[pdf_cv_id]/page.tsx
+++ b/src/app/[lang]/curriculum/pdf/[pdf_cv_id]/page.tsx
@@ -1,0 +1,30 @@
+import { ErrorContent } from '@/components/content';
+import { CVPDFTemplateContent } from '@/components/content/curriculum';
+import { ErrorContentProps } from '@/components/content/ErrorContent/ErrorContent.types';
+import { CVPDFTemplate } from '@/components/layout';
+import ajax from '@/hooks/useAjax';
+import { CVData } from '@/types/database.types';
+
+export default async function CurriculumPdfPage({ params }: { params: Promise<{ pdf_cv_id: string, lang: string }> }) {
+   const { lang, pdf_cv_id } = await params;
+
+   if (isNaN(Number(pdf_cv_id))) {
+      return <ErrorContent message="Invalid CV ID" code="INVALID_CV_ID" />;
+   }
+
+   try {
+      const response = await ajax.get<CVData>(`/curriculum/public/${pdf_cv_id}`, { params: { language_set: lang } });
+
+      if (!response.success) {
+         throw response;
+      }
+
+      return (
+         <CVPDFTemplate language={lang}>
+            <CVPDFTemplateContent cv={response.data} />
+         </CVPDFTemplate>
+      );
+   } catch (error) {
+      return <ErrorContent {...(error as ErrorContentProps)} />;
+   }
+}

--- a/src/components/common/Container/Container.scss
+++ b/src/components/common/Container/Container.scss
@@ -2,11 +2,10 @@
 
 .Container {
    margin: 0 auto;
-   width: 95%;
+   width: 97%;
    max-width: $screen-xl;
 
-   .fullwidth {
-      width: 100%;
+   &.fullwidth {
       max-width: none;
    }
 }

--- a/src/components/content/curriculum/CVPDFTemplateContent/CVPDFTemplateContent.module.scss
+++ b/src/components/content/curriculum/CVPDFTemplateContent/CVPDFTemplateContent.module.scss
@@ -1,0 +1,160 @@
+@use '@/style/variables' as *;
+
+.CVPDFTemplateContent {
+   h1 {
+      font-size: 1.6rem;
+   }
+
+   h2 {
+      font-size: 1.30rem;
+      margin-top: 0.5rem;
+      margin-bottom: 0.75rem;
+   }
+
+   h3 {
+      font-size: 1.2rem;
+   }
+
+   h4 {
+      font-size: 1.1rem;
+   }
+
+   h5 {
+      font-size: 1rem;
+   }
+
+   hr {
+      margin: 0.5rem 0;
+   }
+
+   ul {
+      margin: 1rem 0;
+
+      li {
+         margin-bottom: 1rem;
+         list-style: none;
+
+         label {
+            margin-right: 0.5rem;
+         }
+      }
+   }
+
+   p {
+      font-size: 0.95rem;
+   }
+
+   a {
+      text-decoration: underline;
+   }
+
+   section,
+   header {
+      padding-bottom: $padding-l;
+   }
+
+   section {
+      .sectionTitle {
+         padding: $padding-l 0;
+         background-color: $background-dark;
+
+         h2 {
+            margin: 0;
+         }
+      }
+   }
+
+   header {
+      padding-top: $padding-l;
+   }
+
+   .chipsList {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+      margin-bottom: 0;
+
+      li {
+         background: $tertiary;
+         color: $text-contrast;
+         border-radius: $radius-xs;
+         padding: 0.4rem 0.75rem;
+         margin-bottom: 0;
+         font-size: 0.85rem;
+      }
+   }
+   
+   .CVPDFHeader {
+      p {
+         font-size: 1.1rem;
+         font-weight: 500;
+         margin-bottom: 1rem;
+      }
+
+      .headerSummary {
+         p {
+            color: $text-soft;
+            font-size: 0.9rem;
+            margin-bottom: 0.5rem;
+         }
+      }
+
+      .contactInfos {
+         ul {
+            display: flex;
+            flex-wrap: wrap;
+
+            li {
+               flex: 50%;
+               display: flex;
+               align-items: center;
+               margin-bottom: 0.4rem;
+
+               a {
+                  font-size: 0.85rem;
+                  color: $text-soft;
+               }
+            }
+         }
+      }
+   
+      .horizontalList {
+         display: flex;
+         justify-content: space-between;
+         flex-wrap: wrap;
+
+         li {
+            margin-right: 0.5rem;
+            display: inline-flex;
+            align-items: center;
+            
+            &:not(:last-child) {
+               margin-right: 0.5rem;
+            }
+         }
+      }
+   }
+
+   .CVPDFExperiences {
+      .experienceHeader {
+         background-color: $background-dark;
+         border-left: 3px solid $primary;
+
+         .chipsList {
+            li {
+               background: $disabled;
+               font-size: 0.85rem;
+            }
+         }
+      }
+
+      .experienceDetails {
+         background-color: $background-dark;
+
+         h4 {
+            margin-top: 0.5rem;
+            margin-bottom: 0.25rem;
+         }
+      }
+   }
+}

--- a/src/components/content/curriculum/CVPDFTemplateContent/CVPDFTemplateContent.tsx
+++ b/src/components/content/curriculum/CVPDFTemplateContent/CVPDFTemplateContent.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { CVPDFTemplateContentProps } from './CVPDFTemplateContent.types';
+import CVPDFTemplateProvider from './CVPDFTemplateContext';
+import CVPDFHeader from './sections/CVPDFHeader';
+import CVPDFSkills from './sections/CVPDFSkills';
+import CVPDFExperiences from './sections/CVPDFExperience';
+import { parseCSS } from '@/helpers/parse.helpers';
+import styles from './CVPDFTemplateContent.module.scss';
+
+export default function CVPDFTemplateContent({ cv }: CVPDFTemplateContentProps): React.ReactElement {
+   const CSS = parseCSS('CVPDFTemplateContent', styles.CVPDFTemplateContent);
+
+   return (
+      <CVPDFTemplateProvider cv={cv}>
+         <div className={CSS}>
+            <CVPDFHeader />
+            <CVPDFSkills />
+            <CVPDFExperiences />
+         </div>
+      </CVPDFTemplateProvider>
+   );
+}

--- a/src/components/content/curriculum/CVPDFTemplateContent/CVPDFTemplateContent.types.ts
+++ b/src/components/content/curriculum/CVPDFTemplateContent/CVPDFTemplateContent.types.ts
@@ -1,0 +1,14 @@
+import { CVData } from "@/types/database.types";
+
+export interface CVPDFTemplateContentProps {
+   cv: CVData;
+}
+
+export interface CVPDFTemplateContextProps {
+   cv: CVData;
+   children: React.ReactNode;
+}
+
+export interface CVPDFHeaderProps {
+   className?: string;
+}

--- a/src/components/content/curriculum/CVPDFTemplateContent/CVPDFTemplateContext.tsx
+++ b/src/components/content/curriculum/CVPDFTemplateContent/CVPDFTemplateContext.tsx
@@ -1,0 +1,23 @@
+import { CVData } from '@/types/database.types';
+import { createContext, useContext } from 'react';
+import { CVPDFTemplateContextProps } from './CVPDFTemplateContent.types';
+
+export const CVPDFTemplateContext = createContext<CVData | null>(null);
+
+export default function CVPDFTemplateProvider({ cv, children }: CVPDFTemplateContextProps): React.ReactElement {
+   return (
+      <CVPDFTemplateContext.Provider value={cv}>
+         {children}
+      </CVPDFTemplateContext.Provider>
+   );
+}
+
+export function useCVPDFTemplate() {
+   const context = useContext(CVPDFTemplateContext);
+
+   if (context === null) {
+      throw new Error('useCVPDFTemplate must be used within an CVPDFTemplateProvider');
+   }
+
+   return context;
+}

--- a/src/components/content/curriculum/CVPDFTemplateContent/sections/CVPDFExperience.tsx
+++ b/src/components/content/curriculum/CVPDFTemplateContent/sections/CVPDFExperience.tsx
@@ -1,0 +1,63 @@
+import { Card, Container, DateView, Markdown } from '@/components/common';
+import { useCVPDFTemplate } from '../CVPDFTemplateContext';
+import styles from '../CVPDFTemplateContent.module.scss';
+import { parseCSS } from '@/helpers/parse.helpers';
+import { CardProps } from '@/components/common/Card/Card.types';
+import { ContentSidebar } from '@/components/layout';
+import { Fragment } from 'react';
+
+export default function CVPDFExperiences(): React.ReactElement {
+   const cv = useCVPDFTemplate();
+   const CSS = parseCSS('CVPDFExperiences', styles.CVPDFExperiences);
+   const cardProps: CardProps = { elevation: 'none', padding: 'm' };
+
+   return (
+      <section className={CSS}>
+         <div className={styles.sectionTitle}>
+            <Container fullwidth>
+               <h2>Work Experience</h2>
+               <p>Check below a summary of my work experience.</p>
+            </Container>
+         </div>
+
+         <Container fullwidth>
+            {cv.cv_experiences?.length ? (
+               <ul>
+                  {cv.cv_experiences.map((experience, index) => (
+                     <li key={index}>
+                        <Card className={styles.experienceHeader} {...cardProps}>
+                           <h3>{experience.position} at {experience.company?.company_name}</h3>
+                           <p><DateView date={experience.start_date} /> - <DateView date={experience.end_date} /></p>
+
+                           <ul className={styles.chipsList}>
+                              {experience.skills?.map((skill, index) => (
+                                 <li key={index}>{skill.name}</li>
+                              ))}
+                           </ul>
+                        </Card>
+
+                        <Card className={styles.experienceDetails} {...cardProps}>
+                           <ContentSidebar breakpoint="m">
+                              <Fragment>
+                                 <h4>Summary</h4>
+                                 <Markdown value={experience.summary} />
+
+                                 <h4>Description</h4>
+                                 <Markdown value={experience.description} />
+                              </Fragment>
+                              <Fragment>
+                                 <h4>Responsibilities</h4>
+                                 <Markdown value={experience.responsibilities} />
+                              </Fragment>
+                           </ContentSidebar>
+                        </Card>
+                     </li>
+                  ))}
+               </ul>
+            ) : (
+               <p>No experience listed.</p>
+            )}
+         </Container>
+      </section>
+   );
+}

--- a/src/components/content/curriculum/CVPDFTemplateContent/sections/CVPDFHeader.tsx
+++ b/src/components/content/curriculum/CVPDFTemplateContent/sections/CVPDFHeader.tsx
@@ -1,0 +1,60 @@
+import Link from 'next/link';
+import { useCVPDFTemplate } from '../CVPDFTemplateContext';
+import { parseCSS } from '@/helpers/parse.helpers';
+import styles from '../CVPDFTemplateContent.module.scss';
+import { Container, Markdown } from '@/components/common';
+import { Email, GitHub, LinkedIn, Monitor, Phone, WhatsApp } from '@mui/icons-material';
+
+export default function CVPDFHeader({ className }: { className?: string }): React.ReactElement {
+   const cv = useCVPDFTemplate();
+   const iconSize = 'small';
+   const CSS = parseCSS(className, [
+      'CVPDFHeader',
+      styles.CVPDFHeader,
+   ]);
+
+   return (
+      <header className={CSS}>
+         <Container className={styles.headerFlex} fullwidth>
+            <div className={styles.headerInfo}>
+               <h1>{cv.user?.first_name} {cv.user?.last_name}</h1>
+               <p>{cv.job_title}</p>
+            </div>
+            
+            <Markdown
+               className={styles.headerSummary}
+               value={cv.summary}
+            />
+
+            <div className={styles.contactInfos}> 
+               <ul>
+                  <li>
+                     <label><Email fontSize={iconSize} /></label>
+                     <Link href={`mailto:${cv.user?.email}`}>{cv.user?.email}</Link>
+                  </li>
+                  <li>
+                     <label><Phone fontSize={iconSize} /></label>
+                     <Link href={`tel:${cv.user?.phone}`}>{cv.user?.phone}</Link>
+                  </li>
+                  <li>
+                     <label><GitHub fontSize={iconSize} /></label>
+                     <Link href={cv.user?.github_url || '#'}>GitHub Profile</Link>
+                  </li>
+                  <li>
+                     <label><LinkedIn fontSize={iconSize} /></label>
+                     <Link href={cv.user?.linkedin_url || '#'}>LinkedIn Profile</Link>
+                  </li>
+                  <li>
+                     <label><Monitor fontSize={iconSize} /></label>
+                     <Link href={cv.user?.portfolio_url || '#'}>Website</Link>
+                  </li>
+                  <li>
+                     <label><WhatsApp fontSize={iconSize} /></label>
+                     <Link href={`https://wa.me/${cv.user?.whatsapp_number}`}>WhatsApp</Link>
+                  </li>
+               </ul>
+            </div>
+         </Container>
+      </header>
+   );
+}

--- a/src/components/content/curriculum/CVPDFTemplateContent/sections/CVPDFSkills.tsx
+++ b/src/components/content/curriculum/CVPDFTemplateContent/sections/CVPDFSkills.tsx
@@ -1,0 +1,26 @@
+import { parseCSS } from '@/helpers/parse.helpers';
+import { useCVPDFTemplate } from '../CVPDFTemplateContext';
+import styles from '../CVPDFTemplateContent.module.scss';
+import { Container } from '@/components/common';
+
+export default function CVPDFSkills(): React.ReactElement {
+   const cv = useCVPDFTemplate();
+   const CSS = parseCSS('CVPDFSkills', styles.CVPDFSkills);
+
+   return (
+      <section className={CSS}>
+         <div className={styles.sectionTitle}>
+            <Container fullwidth>
+               <h2>Skills</h2>
+               <p>Programming Languages, Frameworks, Development Tools, Libraries, and others.</p>
+
+               <ul className={styles.chipsList}>
+                  {cv.cv_skills?.map((skill, index) => (
+                     <li key={index}>{skill.name}</li>
+                  ))}
+               </ul>
+            </Container>
+         </div>
+      </section>
+   );
+}

--- a/src/components/content/curriculum/index.tsx
+++ b/src/components/content/curriculum/index.tsx
@@ -1,0 +1,1 @@
+export { default as CVPDFTemplateContent } from './CVPDFTemplateContent/CVPDFTemplateContent';

--- a/src/components/footers/BasicFooter/BasicFooter.tsx
+++ b/src/components/footers/BasicFooter/BasicFooter.tsx
@@ -1,14 +1,15 @@
 import { Container } from "@/components/common";
 import { useTextResources } from "@/services/TextResources/TextResourcesProvider";
 import basicFooterText from "./BasicFooter.text";
+import { BasicFooterProps } from "./BasicFooter.types";
 
-export default function BasicFooter() {
+export default function BasicFooter({ fullwidth }: BasicFooterProps): React.JSX.Element {
    const { textResources } = useTextResources(basicFooterText);
    const copyrightText = textResources.getText('BasicFooter.copyright');
 
    return (
       <footer className="BasicFooter">
-         <Container>
+         <Container fullwidth={fullwidth}>
             <p className="company-info">{copyrightText}</p>
          </Container>
       </footer>

--- a/src/components/footers/BasicFooter/BasicFooter.types.ts
+++ b/src/components/footers/BasicFooter/BasicFooter.types.ts
@@ -1,0 +1,3 @@
+export interface BasicFooterProps {
+   fullwidth?: boolean;
+}

--- a/src/components/headers/TopHeader/TopHeader.tsx
+++ b/src/components/headers/TopHeader/TopHeader.tsx
@@ -4,10 +4,10 @@ import Link from 'next/link';
 import { TopHeaderProps } from './TopHeader.types';
 import Image from 'next/image';
 
-export default function TopHeader({ adminMenus }: TopHeaderProps): React.JSX.Element {
+export default function TopHeader({ adminMenus, fullwidth }: TopHeaderProps): React.JSX.Element {
    return (
       <header className="TopHeader">
-         <Container>
+         <Container fullwidth={fullwidth}>
             <Link href="/">
                <Logo />
             </Link>

--- a/src/components/headers/TopHeader/TopHeader.types.ts
+++ b/src/components/headers/TopHeader/TopHeader.types.ts
@@ -1,3 +1,4 @@
 export interface TopHeaderProps {
    adminMenus?: boolean;
+   fullwidth?: boolean;
 }

--- a/src/components/layout/CVPDFTemplate/CVPDFTemplate.tsx
+++ b/src/components/layout/CVPDFTemplate/CVPDFTemplate.tsx
@@ -1,0 +1,14 @@
+import PageBase from "../PageBase/PageBase";
+import { PageBaseProps } from "../PageBase/PageBase.types";
+
+export default function CVPDFTemplate({ language, children }: PageBaseProps): React.ReactElement {
+   return (
+      <PageBase
+         language={language}
+         fullwidth
+         hideFooter
+      >
+         {children}
+      </PageBase>
+   );
+}

--- a/src/components/layout/ContentSidebar/ContentSidebar.scss
+++ b/src/components/layout/ContentSidebar/ContentSidebar.scss
@@ -7,8 +7,28 @@
    column-gap: 4%;
    width: 100%;
 
-   @media screen and (min-width: $screen-m) {
-      flex-direction: row;
+   &.breakpoint-s {
+      @media screen and (min-width: $screen-s) {
+         flex-direction: row;
+      }
+   }
+
+   &.breakpoint-m {
+      @media screen and (min-width: $screen-m) {
+         flex-direction: row;
+      }
+   }
+
+   &.breakpoint-l {
+      @media screen and (min-width: $screen-l) {
+         flex-direction: row;
+      }
+   }
+
+   &.breakpoint-xl {
+      @media screen and (min-width: $screen-xl) {
+         flex-direction: row;
+      }
    }
    
    &.reverse-row {

--- a/src/components/layout/ContentSidebar/ContentSidebar.test.tsx
+++ b/src/components/layout/ContentSidebar/ContentSidebar.test.tsx
@@ -5,11 +5,13 @@ import { parseCSS } from '@/helpers/parse.helpers';
 
 // Mock the parseCSS utility
 jest.mock('@/helpers/parse.helpers', () => ({
-   parseCSS: jest.fn()
+   parseCSS: jest.fn(),
+   parseBreakpoint: jest.fn()
 }));
 
 describe('ContentSidebar', () => {
    const mockParseCSS = parseCSS as jest.MockedFunction<typeof parseCSS>;
+   const mockParseBreakpoint = require('@/helpers/parse.helpers').parseBreakpoint as jest.MockedFunction<any>;
 
    beforeEach(() => {
       // Default mock implementation
@@ -19,7 +21,7 @@ describe('ContentSidebar', () => {
          }
          return [className, classes].filter(Boolean).join(' ');
       });
-
+      mockParseBreakpoint.mockImplementation(() => 'breakpoint-m');
       jest.clearAllMocks();
    });
 
@@ -172,6 +174,7 @@ describe('ContentSidebar', () => {
 
          expect(mockParseCSS).toHaveBeenCalledWith('', [
             'ContentSidebar',
+            'breakpoint-m',
             '',
             ''
          ]);
@@ -182,6 +185,7 @@ describe('ContentSidebar', () => {
 
          expect(mockParseCSS).toHaveBeenCalledWith('custom-class', [
             'ContentSidebar',
+            'breakpoint-m',
             '',
             ''
          ]);
@@ -192,6 +196,7 @@ describe('ContentSidebar', () => {
 
          expect(mockParseCSS).toHaveBeenCalledWith('', [
             'ContentSidebar',
+            'breakpoint-m',
             'reverse-column',
             ''
          ]);
@@ -202,6 +207,7 @@ describe('ContentSidebar', () => {
 
          expect(mockParseCSS).toHaveBeenCalledWith('', [
             'ContentSidebar',
+            'breakpoint-m',
             '',
             'reverse-row'
          ]);
@@ -212,6 +218,7 @@ describe('ContentSidebar', () => {
 
          expect(mockParseCSS).toHaveBeenCalledWith('', [
             'ContentSidebar',
+            'breakpoint-m',
             'reverse-column',
             'reverse-row'
          ]);
@@ -228,6 +235,7 @@ describe('ContentSidebar', () => {
 
          expect(mockParseCSS).toHaveBeenCalledWith('custom-class', [
             'ContentSidebar',
+            'breakpoint-m',
             'reverse-column',
             'reverse-row'
          ]);
@@ -249,6 +257,7 @@ describe('ContentSidebar', () => {
 
          expect(mockParseCSS).toHaveBeenCalledWith('', [
             'ContentSidebar',
+            'breakpoint-m',
             'reverse-column',
             ''
          ]);
@@ -259,6 +268,7 @@ describe('ContentSidebar', () => {
 
          expect(mockParseCSS).toHaveBeenCalledWith('', [
             'ContentSidebar',
+            'breakpoint-m',
             '',
             'reverse-row'
          ]);
@@ -269,16 +279,18 @@ describe('ContentSidebar', () => {
 
          expect(mockParseCSS).toHaveBeenCalledWith('test-class', [
             'ContentSidebar',
+            'breakpoint-m',
             '',
             ''
          ]);
       });
 
       it('handles className as array', () => {
-         render(<ContentSidebar className={['class1', 'class2']} />);
+         render(<ContentSidebar className={["class1", "class2"]} />);
 
-         expect(mockParseCSS).toHaveBeenCalledWith(['class1', 'class2'], [
+         expect(mockParseCSS).toHaveBeenCalledWith(["class1", "class2"], [
             'ContentSidebar',
+            'breakpoint-m',
             '',
             ''
          ]);
@@ -289,6 +301,7 @@ describe('ContentSidebar', () => {
 
          expect(mockParseCSS).toHaveBeenCalledWith('', [
             'ContentSidebar',
+            'breakpoint-m',
             '',
             ''
          ]);
@@ -299,6 +312,7 @@ describe('ContentSidebar', () => {
 
          expect(mockParseCSS).toHaveBeenCalledWith('', [
             'ContentSidebar',
+            'breakpoint-m',
             '',
             ''
          ]);
@@ -311,6 +325,7 @@ describe('ContentSidebar', () => {
 
          expect(mockParseCSS).toHaveBeenCalledWith('', [
             'ContentSidebar',
+            'breakpoint-m',
             '',
             ''
          ]);
@@ -337,6 +352,7 @@ describe('ContentSidebar', () => {
 
          expect(mockParseCSS).toHaveBeenCalledWith('', [
             'ContentSidebar',
+            'breakpoint-m',
             '',
             ''
          ]);
@@ -396,6 +412,7 @@ describe('ContentSidebar', () => {
 
          expect(mockParseCSS).toHaveBeenLastCalledWith('', [
             'ContentSidebar',
+            'breakpoint-m',
             '',
             ''
          ]);
@@ -404,6 +421,7 @@ describe('ContentSidebar', () => {
 
          expect(mockParseCSS).toHaveBeenLastCalledWith('', [
             'ContentSidebar',
+            'breakpoint-m',
             'reverse-column',
             ''
          ]);
@@ -637,6 +655,7 @@ describe('ContentSidebar', () => {
 
          expect(mockParseCSS).toHaveBeenCalledWith('', [
             'ContentSidebar',
+            'breakpoint-m',
             'reverse-column',
             'reverse-row'
          ]);

--- a/src/components/layout/ContentSidebar/ContentSidebar.test.tsx
+++ b/src/components/layout/ContentSidebar/ContentSidebar.test.tsx
@@ -1,9 +1,9 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import ContentSidebar from './ContentSidebar';
-import { parseCSS } from '@/helpers/parse.helpers';
+import { parseCSS, parseBreakpoint } from '@/helpers/parse.helpers';
 
-// Mock the parseCSS utility
+// Mock the parseCSS and parseBreakpoint utilities
 jest.mock('@/helpers/parse.helpers', () => ({
    parseCSS: jest.fn(),
    parseBreakpoint: jest.fn()
@@ -11,7 +11,7 @@ jest.mock('@/helpers/parse.helpers', () => ({
 
 describe('ContentSidebar', () => {
    const mockParseCSS = parseCSS as jest.MockedFunction<typeof parseCSS>;
-   const mockParseBreakpoint = require('@/helpers/parse.helpers').parseBreakpoint as jest.MockedFunction<any>;
+   const mockParseBreakpoint = parseBreakpoint as jest.MockedFunction<typeof parseBreakpoint>;
 
    beforeEach(() => {
       // Default mock implementation

--- a/src/components/layout/ContentSidebar/ContentSidebar.tsx
+++ b/src/components/layout/ContentSidebar/ContentSidebar.tsx
@@ -1,21 +1,24 @@
 import React from 'react';
-import { parseCSS } from '@/helpers/parse.helpers';
+import { parseBreakpoint, parseCSS, SizeKeyword } from '@/helpers/parse.helpers';
 
 interface ContentSidebarProps {
    reverseColumn?: boolean;
    reverseRow?: boolean;
+   breakpoint?: SizeKeyword;
    className?: string | string[];
    children?: React.ReactNode;
 }
 
 export default function ContentSidebar({ 
-   reverseColumn, 
-   reverseRow, 
-   className = '', 
-   children 
+   reverseColumn,
+   reverseRow,
+   breakpoint = 'm',
+   className = '',
+   children
 }: ContentSidebarProps): React.JSX.Element {
    const classeNames = parseCSS(className, [
       'ContentSidebar',
+      parseBreakpoint(breakpoint),
       reverseColumn ? 'reverse-column' : '',
       reverseRow ? 'reverse-row' : ''
    ]);

--- a/src/components/layout/PageBase/PageBase.tsx
+++ b/src/components/layout/PageBase/PageBase.tsx
@@ -10,15 +10,24 @@ import { TopHeader } from '@/components/headers';
 import { BasicFooter } from '@/components/footers';
 import { TextResourcesProvider } from '@/services/TextResources/TextResourcesProvider';
 
-export default function PageBase({ language, children }: PageBaseProps): React.ReactElement {
+export default function PageBase({
+   language,
+   hideFooter = false,
+   fullwidth = false,
+   customHeader,
+   children
+}: PageBaseProps): React.ReactElement {
+   const Header = (): React.ReactNode => customHeader || <TopHeader fullwidth={fullwidth} />;
+   const Footer = (): React.ReactNode => !hideFooter && <BasicFooter fullwidth={fullwidth} />;
+
    return (
       <main className="PageBase">
          <TextResourcesProvider language={language}>
             <Provider store={store}>
                <ThemeProvider theme={defaultTheme}>
-                  <TopHeader />
+                  <Header />
                   {children}
-                  <BasicFooter />
+                  <Footer />
                </ThemeProvider>
             </Provider>
          </TextResourcesProvider>

--- a/src/components/layout/PageBase/PageBase.types.tsx
+++ b/src/components/layout/PageBase/PageBase.types.tsx
@@ -1,4 +1,7 @@
 export interface PageBaseProps {
    language?: string;
+   hideFooter?: boolean;
+   customHeader?: React.ReactNode;
+   fullwidth?: boolean;
    children: React.ReactNode;
 }

--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -1,5 +1,6 @@
 export { default as PageBase } from './PageBase/PageBase';
 export { default as AdminPageBase } from './AdminPageBase/AdminPageBase';
+export { default as CVPDFTemplate } from './CVPDFTemplate/CVPDFTemplate';
 export { default as ContentSidebar } from './ContentSidebar/ContentSidebar';
 export { default as DataContainer } from './DataContainer/DataContainer';
 export { default as TabsContent } from './TabsContent/TabsContent';

--- a/src/helpers/parse.helpers.ts
+++ b/src/helpers/parse.helpers.ts
@@ -73,6 +73,24 @@ export function parseElevation(size: SizeKeyword): string {
    }
 }
 
+export function parseBreakpoint(size: SizeKeyword): string {
+   switch (size) {
+      case 'xs':
+         return 'breakpoint-xs';
+      case 's':
+         return 'breakpoint-s';
+      case 'm':
+         return 'breakpoint-m';
+      case 'l':
+         return 'breakpoint-l';
+      case 'xl':
+         return 'breakpoint-xl';
+      case 'none':
+      default:
+         return '';
+   }
+}
+
 /**
  * Combines one or two sets of CSS class names into a single string.
  * Accepts strings or arrays of strings and filters out falsy values.

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -1,3 +1,5 @@
+import { UserData } from '@/services/Auth/Auth.types';
+
 export type ExperienceDataStatus = 'draft' | 'published' | 'archived';
 export type ExperienceDataType = 'internship' | 'freelance' | 'contract' | 'temporary' | 'full_time' | 'part_time' | 'other';
 
@@ -75,4 +77,5 @@ export interface CVSetData extends BasicData {
    job_title?: string;
    user_id: number;
    cv_id: number;
+   user?: UserData;
 }


### PR DESCRIPTION
## [FRD-113] Description
This pull request introduces a new feature for generating PDF versions of CVs, alongside some general layout and styling updates. The most significant changes include the creation of a `CVPDFTemplateContent` component with its associated context and styles, updates to layout components to support full-width rendering, and improvements to the `ContentSidebar` for better responsiveness.

### New CV PDF Feature

* **New `CurriculumPdfPage` implementation**: Added a server-side rendered page that fetches CV data and renders it using the `CVPDFTemplate` and `CVPDFTemplateContent` components. Includes error handling for invalid IDs or failed API responses. (`src/app/[lang]/curriculum/pdf/[pdf_cv_id]/page.tsx`) ([src/app/[lang]/curriculum/pdf/[pdf_cv_id]/page.tsxR1-R30](diffhunk://#diff-465cf6cf58209e8002c78d7ea1ef016d316b5bd2f96dfac2ba3e6264be646b43R1-R30))
* **`CVPDFTemplateContent` component**: Introduced a new component to render CV content, including sections for header, skills, and experiences. It uses a context provider (`CVPDFTemplateContext`) to share CV data across sections. (`src/components/content/curriculum/CVPDFTemplateContent/CVPDFTemplateContent.tsx`)
* **Context and types for CV data**: Added `CVPDFTemplateContext` to provide CV data to child components and defined associated TypeScript interfaces. (`src/components/content/curriculum/CVPDFTemplateContent/CVPDFTemplateContext.tsx`, `src/components/content/curriculum/CVPDFTemplateContent/CVPDFTemplateContent.types.ts`) [[1]](diffhunk://#diff-a3e2a3b7eb9db51f8af7607aa9d69daf1b0ec6b79f37ab518b5fe68b0d97fa6fR1-R23) [[2]](diffhunk://#diff-9143d2ad26ebcf6e260a8ea88f9744198728d55943a95fcb567cac34e3f66d58R1-R14)
* **Styling for CV PDF components**: Created a dedicated SCSS module for `CVPDFTemplateContent`, including styles for headers, sections, lists, and cards. (`src/components/content/curriculum/CVPDFTemplateContent/CVPDFTemplateContent.module.scss`)

### Layout Enhancements

* **`CVPDFTemplate` layout**: Added a new layout component for rendering CV PDFs, extending `PageBase` with options to hide the footer and enable full-width rendering. (`src/components/layout/CVPDFTemplate/CVPDFTemplate.tsx`)
* **Improved `PageBase` flexibility**: Updated `PageBase` to accept `hideFooter`, `customHeader`, and `fullwidth` props, allowing more customizable layouts. (`src/components/layout/PageBase/PageBase.tsx`, `src/components/layout/PageBase/PageBase.types.tsx`) [[1]](diffhunk://#diff-4afa853aeba276cfce6ea49b1f189c21a7b55dae36bf29900f652634717d9786L13-R30) [[2]](diffhunk://#diff-39adaec5faa2366356cfa6233e801c60ef8d10495d7f6d3b5778fec3f8957446R3-R5)
* **Full-width support for `Container`**: Adjusted the `Container` component to support a `fullwidth` class for edge-to-edge layouts. (`src/components/common/Container/Container.scss`)

### Responsiveness and Styling

* **`ContentSidebar` enhancements**: Added breakpoint-specific classes for responsive row layouts, improving flexibility in sidebar content alignment. (`src/components/layout/ContentSidebar/ContentSidebar.scss`, `src/components/layout/ContentSidebar/ContentSidebar.tsx`) [[1]](diffhunk://#diff-b78c347896ee0f9ed4e56a138bdb60615c4d9fec4473925a15efc150da19c31eR10-R32) [[2]](diffhunk://#diff-11e4ffba3eb48914052fcde881ba82b1ed34a83e6ea566d8b312dae1555a5e5dL2-R21)
* **Minor updates to headers and footers**: Updated `TopHeader` and `BasicFooter` components to support the new `fullwidth` prop for consistent layout behavior. (`src/components/headers/TopHeader/TopHeader.tsx`, `src/components/headers/TopHeader/TopHeader.types.ts`, `src/components/footers/BasicFooter/BasicFooter.tsx`, `src/components/footers/BasicFooter/BasicFooter.types.ts`) [[1]](diffhunk://#diff-ed7f6ee706bba2ca37ca9b1a7a8d4f3ba07330c15411bca3a4f9ee925f3bfef0L7-R10) [[2]](diffhunk://#diff-3eb8a1343372ff76ece5dee5b2bb307e447585d270559f34f17cd8e5b8ced6b0R3) [[3]](diffhunk://#diff-d9607391fef3ded3e915921cfdbdbf40ea68b2a1bc378d482941155626a0815dR4-R12) [[4]](diffhunk://#diff-66ce4dc70860e84faac013cec40e2b8a4a7873e161ea9c1a4e4e44378c09344bR1-R3)

[FRD-113]: https://feliperamosdev.atlassian.net/browse/FRD-113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ