### PR TITLE
[FRD-127] Download CV auto-generated

### DIFF
--- a/src/components/banners/HomeTopBanner/HomeTopBanner.test.tsx
+++ b/src/components/banners/HomeTopBanner/HomeTopBanner.test.tsx
@@ -213,7 +213,7 @@ describe('HomeTopBanner', () => {
          });
 
          // Mock the downloadCVPDF function to simulate the expected behavior
-         mockDownloadCVPDF.mockImplementation((_cv, _locale) => {
+         mockDownloadCVPDF.mockImplementation(() => {
             const a = document.createElement('a');
             a.target = '_blank';
             a.href = '/cv/felipe_ramos_cv.pdf';

--- a/src/components/banners/HomeTopBanner/HomeTopBanner.tsx
+++ b/src/components/banners/HomeTopBanner/HomeTopBanner.tsx
@@ -7,11 +7,13 @@ import { Download } from '@mui/icons-material';
 import { Button } from '@mui/material';
 import homeTopBannerText from './HomeTopBanner.text';
 import { useTextResources } from '@/services/TextResources/TextResourcesProvider';
+import { HomeTopBannerProps } from './HomeTopBanner.types';
+import { downloadCVPDF } from '@/helpers/app.helpers';
 
 const HOST = process.env.NEXT_PUBLIC_SERVER_HOST || 'http://localhost';
 const PORT = process.env.NEXT_PUBLIC_SERVER_SOCKET_PORT || '5000';
 
-export default function HomeTopBanner(): React.ReactElement {
+export default function HomeTopBanner({ cv }: HomeTopBannerProps): React.ReactElement {
    const { textResources } = useTextResources(homeTopBannerText);
    const url = new URL(HOST);
 
@@ -23,15 +25,7 @@ export default function HomeTopBanner(): React.ReactElement {
       autoConnect: false
    };
 
-   const downloadCV = () => {
-      const link = document.createElement('a');
-
-      link.target = '_blank';
-      link.href = '/cv/felipe_ramos_cv.pdf';
-      link.download = 'felipe_ramos_cv.pdf';
-
-      link.click();
-   }
+   const downloadCV = () => downloadCVPDF(cv, textResources.currentLanguage);
 
    return (
       <section className="HomeBanner">

--- a/src/components/banners/HomeTopBanner/HomeTopBanner.types.ts
+++ b/src/components/banners/HomeTopBanner/HomeTopBanner.types.ts
@@ -1,0 +1,5 @@
+import { CVData } from "@/types/database.types";
+
+export interface HomeTopBannerProps {
+   cv: CVData;
+}

--- a/src/components/content/HomeContent/HomeContent.tsx
+++ b/src/components/content/HomeContent/HomeContent.tsx
@@ -9,7 +9,7 @@ export default async function HomeContent({ language = 'en' }: { language?: stri
 
    return (
       <div className="HomeContent">
-         <HomeTopBanner />
+         <HomeTopBanner cv={cvData} />
 
          {cvData && (<>
             <Skills skills={cvData?.cv_skills as SkillData[]} />

--- a/src/components/content/admin/curriculum/CVDetailsContent/CVDetailsContent.module.scss
+++ b/src/components/content/admin/curriculum/CVDetailsContent/CVDetailsContent.module.scss
@@ -10,6 +10,16 @@
    }
 }
 
+.pdfDownload {
+   width: 100%;
+   display: flex;
+   gap: 1rem;
+
+   .downloadButton {
+      flex: 1;
+   }
+}
+
 .masterDisplay {
    display: flex;
    align-items: center;

--- a/src/components/content/admin/curriculum/CVDetailsContent/CVDetailsContent.text.ts
+++ b/src/components/content/admin/curriculum/CVDetailsContent/CVDetailsContent.text.ts
@@ -38,6 +38,15 @@ textResources.create('CVDetailsSet.noSets', 'No Language Sets Found');
 textResources.create('CVDetailsSet.noSets', 'Nenhum Campo de Idioma Encontrado', 'pt');
 
 // CVDetailsSidebar
+textResources.create('CVDetailsSidebar.pdf.widgetTitle', 'Download PDF');
+textResources.create('CVDetailsSidebar.pdf.widgetTitle', 'Baixar PDF', 'pt');
+
+textResources.create('CVDetailsSidebar.pdf.downloadButton.en', 'English');
+textResources.create('CVDetailsSidebar.pdf.downloadButton.en', 'Inglês', 'pt');
+
+textResources.create('CVDetailsSidebar.pdf.downloadButton.pt', 'Portuguese');
+textResources.create('CVDetailsSidebar.pdf.downloadButton.pt', 'Português', 'pt');
+
 textResources.create('CVDetailsSidebar.field.id.label', 'ID:');
 textResources.create('CVDetailsSidebar.field.id.label', 'ID:', 'pt');
 

--- a/src/components/content/admin/curriculum/CVDetailsContent/subcomponents/CVDetailsSidebar.tsx
+++ b/src/components/content/admin/curriculum/CVDetailsContent/subcomponents/CVDetailsSidebar.tsx
@@ -14,7 +14,7 @@ import { Form, FormSubmit } from '@/hooks';
 import { useAjax } from '@/hooks/useAjax';
 import { useRouter } from 'next/navigation';
 import { Button } from '@mui/material';
-import { cvPDFDownloadLink, downloadCVPDF } from '@/helpers/app.helpers';
+import { cvPDFDownloadLink } from '@/helpers/app.helpers';
 import Link from 'next/link';
 
 export default function CVDetailsSidebar({ cardProps }: CVDetailsSubcomponentProps): React.ReactElement {

--- a/src/components/content/admin/curriculum/CVDetailsContent/subcomponents/CVDetailsSidebar.tsx
+++ b/src/components/content/admin/curriculum/CVDetailsContent/subcomponents/CVDetailsSidebar.tsx
@@ -13,6 +13,9 @@ import styles from '../CVDetailsContent.module.scss';
 import { Form, FormSubmit } from '@/hooks';
 import { useAjax } from '@/hooks/useAjax';
 import { useRouter } from 'next/navigation';
+import { Button } from '@mui/material';
+import { cvPDFDownloadLink, downloadCVPDF } from '@/helpers/app.helpers';
+import Link from 'next/link';
 
 export default function CVDetailsSidebar({ cardProps }: CVDetailsSubcomponentProps): React.ReactElement {
    const [editMode, setEditMode] = useState<boolean>(false);
@@ -49,6 +52,28 @@ export default function CVDetailsSidebar({ cardProps }: CVDetailsSubcomponentPro
 
    return (
       <Fragment>
+         <Card {...cardProps}>
+            <WidgetHeader title={textResources.getText('CVDetailsSidebar.pdf.widgetTitle')} />
+
+            <div className={styles.pdfDownload}>
+               <Button
+                  className={styles.downloadButton}
+                  LinkComponent={Link}
+                  href={cvPDFDownloadLink(cv, 'en')}
+                  target="_blank"
+               >
+                  {textResources.getText('CVDetailsSidebar.pdf.downloadButton.en')}
+               </Button>
+               <Button
+                  className={styles.downloadButton}
+                  LinkComponent={Link}
+                  href={cvPDFDownloadLink(cv, 'pt')}
+                  target="_blank"
+               >
+                  {textResources.getText('CVDetailsSidebar.pdf.downloadButton.pt')}
+               </Button>
+            </div>
+         </Card>
          <Card {...cardProps}>
             {!cv.is_master ? (
                <EditCVMasterForm />

--- a/src/helpers/app.helpers.ts
+++ b/src/helpers/app.helpers.ts
@@ -1,0 +1,60 @@
+import { CVData } from '@/types/database.types';
+import { defaultLanguage } from '@/app.config';
+
+export function apiURL(path: string, queryParams?: Record<string, string>): string {
+   const baseURL = process.env.NEXT_PUBLIC_SERVER_HOST;
+   const port = process.env.NEXT_PUBLIC_SERVER_HTTP_PORT;
+
+   if (!baseURL) {
+      throw new Error('NEXT_PUBLIC_SERVER_HOST is not defined');
+   }
+
+   if (!port) {
+      throw new Error('NEXT_PUBLIC_SERVER_HTTP_PORT is not defined');
+   }
+
+   const url = new URL(baseURL);
+   url.pathname = path;
+   url.port = port;
+
+   if (queryParams) {
+      Object.entries(queryParams).forEach(([key, value]) => {
+         url.searchParams.append(key, value);
+      });
+   }
+
+   return url.toString();
+}
+
+export function cvPDFDownloadLink(cv: CVData, locale: string = defaultLanguage): string {
+   const cvId = cv.id;
+   const userFullName = cv.user?.name?.replace(/ /g, '_');
+
+   if (!cvId || !userFullName) {
+      throw new Error('CV ID or user full name is missing');
+   }
+
+   return apiURL(`/cv/${userFullName}-CV_${cvId}_${locale}.pdf`);
+}
+
+export function downloadCVPDF(cv: CVData, locale: string): void {
+   if (typeof window === 'undefined') {
+      return;
+   }
+
+   if (!cv) {
+      throw new Error('CV data is required to download the PDF');
+   }
+
+   const link = cvPDFDownloadLink(cv, locale);
+   const a = document.createElement('a');
+   const userFullName = cv.user?.name;
+   const cvId = cv.id;
+
+   a.href = link;
+   a.download = `${userFullName}-${cvId}(${locale}).pdf`;
+
+   document.body.appendChild(a);
+   a.click();
+   document.body.removeChild(a);
+}


### PR DESCRIPTION
## [FRD-127] Description
This pull request introduces enhancements to support dynamic CV PDF downloads in multiple languages and improves the modularity of the codebase. The most important changes include refactoring the `HomeTopBanner` component to accept CV data, adding helper functions for generating and downloading CV PDF links, and updating the CV details sidebar to include language-specific download buttons.

### Enhancements to CV PDF Download Functionality:

* **Helper Functions for CV PDF Downloads**: Added `cvPDFDownloadLink` and `downloadCVPDF` functions in `src/helpers/app.helpers.ts` to generate dynamic download links and facilitate PDF downloads. These functions ensure proper error handling and URL construction.
* **Language-Specific Download Buttons**: Updated `CVDetailsSidebar` to include buttons for downloading CV PDFs in English and Portuguese. This includes new UI elements styled with a `.pdfDownload` class in `CVDetailsContent.module.scss`. [[1]](diffhunk://#diff-c27f29a4082eee5a9afe82fe211fae29d2299ecf6d7f2e1b3d4bfc9fd05edd59R55-R76) [[2]](diffhunk://#diff-ebf99394d42f40444180ffad54657d1047e88faad515449ecc89d614463c1686R13-R22)

### Refactoring for Modularity:

* **`HomeTopBanner` Component Update**: Refactored `HomeTopBanner` to accept a `cv` prop of type `HomeTopBannerProps`, enabling it to dynamically handle CV data. The `downloadCV` function now uses the `downloadCVPDF` helper. [[1]](diffhunk://#diff-ca7dd15dfb824ae29ce6a3d742c06c4e317afa1b2ab67b24226e7ca650d4f9c0R10-R16) [[2]](diffhunk://#diff-ca7dd15dfb824ae29ce6a3d742c06c4e317afa1b2ab67b24226e7ca650d4f9c0L26-R28) [[3]](diffhunk://#diff-8012f561984d0e69829b8c6d2ce2770cd3d16653b2fceea835628cc16a61f818R1-R5)
* **Integration with `HomeContent`**: Updated `HomeContent` to pass `cvData` as a prop to `HomeTopBanner`, ensuring seamless integration with the updated component.

### Text Resources for Localization:

* **New Text Resources**: Added text resources for the CV PDF download widget and buttons in both English and Portuguese, supporting localization.

[FRD-127]: https://feliperamosdev.atlassian.net/browse/FRD-127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ