### PR TITLE
[FRD-126] Missing Text Resources

### DIFF
--- a/src/components/content/curriculum/CVPDFTemplateContent/CVPDFTemplateContext.text.ts
+++ b/src/components/content/curriculum/CVPDFTemplateContent/CVPDFTemplateContext.text.ts
@@ -1,0 +1,41 @@
+import { TextResources } from '@/services';
+
+const textResources = new TextResources();
+
+// CVPDFHeader
+textResources.create('CVPDFHeader.header.github', 'GitHub Profile');
+textResources.create('CVPDFHeader.header.github', 'Perfil do GitHub', 'pt');
+
+textResources.create('CVPDFHeader.header.linkedin', 'LinkedIn Profile');
+textResources.create('CVPDFHeader.header.linkedin', 'Perfil do LinkedIn', 'pt');
+
+textResources.create('CVPDFHeader.header.website', 'Website');
+textResources.create('CVPDFHeader.header.website', 'Website', 'pt');
+
+textResources.create('CVPDFHeader.header.whatsapp', 'WhatsApp');
+textResources.create('CVPDFHeader.header.whatsapp', 'WhatsApp', 'pt');
+
+// CVPDFExperiences
+textResources.create('CVPDFExperiences.experiences.title', 'Work Experience');
+textResources.create('CVPDFExperiences.experiences.title', 'Experiência de Trabalho', 'pt');
+
+textResources.create('CVPDFExperiences.experiences.subtitle', 'Check below a summary of my work experience.');
+textResources.create('CVPDFExperiences.experiences.subtitle', 'Confira abaixo um resumo da minha experiência profissional.', 'pt');
+
+textResources.create('CVPDFExperiences.experiences.summary', 'Summary');
+textResources.create('CVPDFExperiences.experiences.summary', 'Resumo', 'pt');
+
+textResources.create('CVPDFExperiences.experiences.description', 'Description');
+textResources.create('CVPDFExperiences.experiences.description', 'Descrição', 'pt');
+
+textResources.create('CVPDFExperiences.experiences.responsibilities', 'Responsibilities');
+textResources.create('CVPDFExperiences.experiences.responsibilities', 'Responsabilidades', 'pt');
+
+// CVPDFSkills
+textResources.create('CVPDFSkills.title', 'Skills');
+textResources.create('CVPDFSkills.title', 'Habilidades', 'pt');
+
+textResources.create('CVPDFSkills.subtitle', 'Programming Languages, Frameworks, Development Tools, Libraries, and others.');
+textResources.create('CVPDFSkills.subtitle', 'Linguagens de Programação, Frameworks, Ferramentas de Desenvolvimento, Bibliotecas e outros', 'pt');
+
+export default textResources;

--- a/src/components/content/curriculum/CVPDFTemplateContent/sections/CVPDFExperience.tsx
+++ b/src/components/content/curriculum/CVPDFTemplateContent/sections/CVPDFExperience.tsx
@@ -5,9 +5,13 @@ import { parseCSS } from '@/helpers/parse.helpers';
 import { CardProps } from '@/components/common/Card/Card.types';
 import { ContentSidebar } from '@/components/layout';
 import { Fragment } from 'react';
+import { useTextResources } from '@/services/TextResources/TextResourcesProvider';
+import texts from '../CVPDFTemplateContext.text';
 
 export default function CVPDFExperiences(): React.ReactElement {
    const cv = useCVPDFTemplate();
+   const { textResources } = useTextResources(texts);
+
    const CSS = parseCSS('CVPDFExperiences', styles.CVPDFExperiences);
    const cardProps: CardProps = { elevation: 'none', padding: 'm' };
 
@@ -15,8 +19,8 @@ export default function CVPDFExperiences(): React.ReactElement {
       <section className={CSS}>
          <div className={styles.sectionTitle}>
             <Container fullwidth>
-               <h2>Work Experience</h2>
-               <p>Check below a summary of my work experience.</p>
+               <h2>{textResources.getText('CVPDFExperiences.experiences.title')}</h2>
+               <p>{textResources.getText('CVPDFExperiences.experiences.subtitle')}</p>
             </Container>
          </div>
 
@@ -39,14 +43,14 @@ export default function CVPDFExperiences(): React.ReactElement {
                         <Card className={styles.experienceDetails} {...cardProps}>
                            <ContentSidebar breakpoint="m">
                               <Fragment>
-                                 <h4>Summary</h4>
+                                 <h4>{textResources.getText('CVPDFExperiences.experiences.summary')}</h4>
                                  <Markdown value={experience.summary} />
 
-                                 <h4>Description</h4>
+                                 <h4>{textResources.getText('CVPDFExperiences.experiences.description')}</h4>
                                  <Markdown value={experience.description} />
                               </Fragment>
                               <Fragment>
-                                 <h4>Responsibilities</h4>
+                                 <h4>{textResources.getText('CVPDFExperiences.experiences.responsibilities')}</h4>
                                  <Markdown value={experience.responsibilities} />
                               </Fragment>
                            </ContentSidebar>

--- a/src/components/content/curriculum/CVPDFTemplateContent/sections/CVPDFHeader.tsx
+++ b/src/components/content/curriculum/CVPDFTemplateContent/sections/CVPDFHeader.tsx
@@ -4,9 +4,13 @@ import { parseCSS } from '@/helpers/parse.helpers';
 import styles from '../CVPDFTemplateContent.module.scss';
 import { Container, Markdown } from '@/components/common';
 import { Email, GitHub, LinkedIn, Monitor, Phone, WhatsApp } from '@mui/icons-material';
+import { useTextResources } from '@/services/TextResources/TextResourcesProvider';
+import texts from '../CVPDFTemplateContext.text';
 
 export default function CVPDFHeader({ className }: { className?: string }): React.ReactElement {
    const cv = useCVPDFTemplate();
+   const { textResources } = useTextResources(texts);
+
    const iconSize = 'small';
    const CSS = parseCSS(className, [
       'CVPDFHeader',
@@ -38,19 +42,19 @@ export default function CVPDFHeader({ className }: { className?: string }): Reac
                   </li>
                   <li>
                      <label><GitHub fontSize={iconSize} /></label>
-                     <Link href={cv.user?.github_url || '#'}>GitHub Profile</Link>
+                     <Link href={cv.user?.github_url || '#'}>{textResources.getText('CVPDFHeader.header.github')}</Link>
                   </li>
                   <li>
                      <label><LinkedIn fontSize={iconSize} /></label>
-                     <Link href={cv.user?.linkedin_url || '#'}>LinkedIn Profile</Link>
+                     <Link href={cv.user?.linkedin_url || '#'}>{textResources.getText('CVPDFHeader.header.linkedin')}</Link>
                   </li>
                   <li>
                      <label><Monitor fontSize={iconSize} /></label>
-                     <Link href={cv.user?.portfolio_url || '#'}>Website</Link>
+                     <Link href={cv.user?.portfolio_url || '#'}>{textResources.getText('CVPDFHeader.header.website')}</Link>
                   </li>
                   <li>
                      <label><WhatsApp fontSize={iconSize} /></label>
-                     <Link href={`https://wa.me/${cv.user?.whatsapp_number}`}>WhatsApp</Link>
+                     <Link href={`https://wa.me/${cv.user?.whatsapp_number}`}>{textResources.getText('CVPDFHeader.header.whatsapp')}</Link>
                   </li>
                </ul>
             </div>

--- a/src/components/content/curriculum/CVPDFTemplateContent/sections/CVPDFSkills.tsx
+++ b/src/components/content/curriculum/CVPDFTemplateContent/sections/CVPDFSkills.tsx
@@ -2,17 +2,20 @@ import { parseCSS } from '@/helpers/parse.helpers';
 import { useCVPDFTemplate } from '../CVPDFTemplateContext';
 import styles from '../CVPDFTemplateContent.module.scss';
 import { Container } from '@/components/common';
+import { useTextResources } from '@/services/TextResources/TextResourcesProvider';
+import texts from '../CVPDFTemplateContext.text';
 
 export default function CVPDFSkills(): React.ReactElement {
    const cv = useCVPDFTemplate();
+   const { textResources } = useTextResources(texts);
    const CSS = parseCSS('CVPDFSkills', styles.CVPDFSkills);
 
    return (
       <section className={CSS}>
          <div className={styles.sectionTitle}>
             <Container fullwidth>
-               <h2>Skills</h2>
-               <p>Programming Languages, Frameworks, Development Tools, Libraries, and others.</p>
+               <h2>{textResources.getText('CVPDFSkills.title')}</h2>
+               <p>{textResources.getText('CVPDFSkills.subtitle')}</p>
 
                <ul className={styles.chipsList}>
                   {cv.cv_skills?.map((skill, index) => (


### PR DESCRIPTION
## [FRD-126] Description
This pull request introduces a localization system for the CV PDF template by integrating a text resource manager. It centralizes text definitions and enables multi-language support, starting with English and Portuguese. Key changes include the creation of a text resource file, updates to the CV sections to use the new system, and dynamic text retrieval for headings and labels.

### Localization Integration:

* Added a new file, `CVPDFTemplateContext.text.ts`, to define and manage text resources for the CV PDF template. This includes English and Portuguese translations for headers, subtitles, and labels across different CV sections.

* Updated `CVPDFExperiences.tsx` to use the `useTextResources` hook for dynamically retrieving localized text for section titles, subtitles, and labels such as "Summary," "Description," and "Responsibilities." [[1]](diffhunk://#diff-5cf965b2af3e3be563e273432ac2c3e129751eab9cc1f4f75899d12e5e64be68R8-R23) [[2]](diffhunk://#diff-5cf965b2af3e3be563e273432ac2c3e129751eab9cc1f4f75899d12e5e64be68L42-R53)

* Updated `CVPDFHeader.tsx` to replace hardcoded text (e.g., "GitHub Profile," "LinkedIn Profile") with localized text retrieved from the text resource manager. [[1]](diffhunk://#diff-6d3910cb1688a831ff62a69386b190dba36193ad64425b26889cddd2cc4cafeaR7-R13) [[2]](diffhunk://#diff-6d3910cb1688a831ff62a69386b190dba36193ad64425b26889cddd2cc4cafeaL41-R57)

* Updated `CVPDFSkills.tsx` to use the text resource manager for the "Skills" section title and subtitle, ensuring localization support.

[FRD-126]: https://feliperamosdev.atlassian.net/browse/FRD-126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ