### PR TITLE
[FRD-128] CV PDF Improvements

### DIFF
--- a/src/components/content/admin/curriculum/CVDetailsContent/CVDetailsContent.text.ts
+++ b/src/components/content/admin/curriculum/CVDetailsContent/CVDetailsContent.text.ts
@@ -21,6 +21,9 @@ textResources.create('CVDetailsInfos.title.label', 'Título', 'pt');
 textResources.create('CVDetailsInfos.notes.label', 'Reference Notes');
 textResources.create('CVDetailsInfos.notes.label', 'Notas de Referência', 'pt');
 
+textResources.create('CVDetailsInfos.experienceTime.label', 'Experience Time');
+textResources.create('CVDetailsInfos.experienceTime.label', 'Tempo de Experiência', 'pt');
+
 // CVDetailsSet
 textResources.create('CVDetailsSet.widgetTitle', 'Language Sets');
 textResources.create('CVDetailsSet.widgetTitle', 'Campos de Idiomas', 'pt');

--- a/src/components/content/admin/curriculum/CVDetailsContent/subcomponents/CVDetailsInfos.tsx
+++ b/src/components/content/admin/curriculum/CVDetailsContent/subcomponents/CVDetailsInfos.tsx
@@ -30,6 +30,10 @@ export default function CVDetailsInfos({ cardProps }: CVDetailsSubcomponentProps
                <p>{cv.title}</p>
             </DataContainer>
             <DataContainer>
+               <label>{textResources.getText('CVDetailsInfos.experienceTime.label')}</label>
+               <p>{cv.experience_time}</p>
+            </DataContainer>
+            <DataContainer>
                <label>{textResources.getText('CVDetailsInfos.notes.label')}</label>
                <p>{cv.notes}</p>
             </DataContainer>

--- a/src/components/content/curriculum/CVPDFTemplateContent/CVPDFTemplateContent.module.scss
+++ b/src/components/content/curriculum/CVPDFTemplateContent/CVPDFTemplateContent.module.scss
@@ -16,7 +16,7 @@
    }
 
    h4 {
-      font-size: 1.1rem;
+      font-size: 1.2rem;
    }
 
    h5 {
@@ -46,6 +46,30 @@
 
    a {
       text-decoration: underline;
+   }
+
+   .markdown {
+      h4 {
+         font-size: 1.1rem;
+      }
+
+      h5 {
+         font-size: 1rem;
+      }
+
+      p {
+         font-size: 0.9rem;
+         line-height: 1.4rem;
+      }
+
+      ul {
+         li {
+            font-size: 0.9rem;
+            list-style: disc;
+            margin-bottom: 0.5rem;
+            line-height: 1.3rem;
+         }
+      }
    }
 
    section,
@@ -88,7 +112,16 @@
       p {
          font-size: 1.1rem;
          font-weight: 500;
+         margin-bottom: 0.15rem;
+      }
+
+      .headerInfo {
          margin-bottom: 1rem;
+
+         span {
+            font-size: 0.95rem;
+            margin-bottom: 2rem;
+         }
       }
 
       .headerSummary {
@@ -139,6 +172,29 @@
       .experienceHeader {
          background-color: $background-dark;
          border-left: 3px solid $primary;
+
+         h3, p {
+            margin-bottom: 0.2rem;
+         }
+
+         h3 {
+            font-size: 1.2rem;
+         }
+
+         p {
+            font-size: 1rem;
+            margin-bottom: 0.4rem;
+         }
+
+         a {
+            font-size: 0.9rem;
+         }
+
+         .verticalAligned {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+         }
 
          .chipsList {
             li {

--- a/src/components/content/curriculum/CVPDFTemplateContent/CVPDFTemplateContext.text.ts
+++ b/src/components/content/curriculum/CVPDFTemplateContent/CVPDFTemplateContext.text.ts
@@ -1,4 +1,16 @@
+import { dataViewString, dateDifference } from '@/helpers/date.helpers';
 import { TextResources } from '@/services';
+
+function dateDiffYearMonth(startDate: string, endDate: string): { year: number, month: number } {
+   const years = dateDifference(new Date(startDate), new Date(endDate), 'year');
+   const months = dateDifference(new Date(startDate), new Date(endDate), 'month');
+   const restMonths = months % 12;
+
+   return {
+      year: years,
+      month: restMonths
+   };
+}
 
 const textResources = new TextResources();
 
@@ -15,9 +27,39 @@ textResources.create('CVPDFHeader.header.website', 'Website', 'pt');
 textResources.create('CVPDFHeader.header.whatsapp', 'WhatsApp');
 textResources.create('CVPDFHeader.header.whatsapp', 'WhatsApp', 'pt');
 
+textResources.create('CVPDFHeader.header.experienceTime', (time: string) => `+${Math.round(Number(time))} years of Experience`);
+textResources.create('CVPDFHeader.header.experienceTime', (time: string) => `+${Math.round(Number(time))} anos de Experiência`, 'pt');
+
 // CVPDFExperiences
 textResources.create('CVPDFExperiences.experiences.title', 'Work Experience');
 textResources.create('CVPDFExperiences.experiences.title', 'Experiência de Trabalho', 'pt');
+
+textResources.create('CVPDFExperiences.experienceHeader.title', (position: string, company: string) => `${position} at ${company}`);
+textResources.create('CVPDFExperiences.experienceHeader.title', (position: string, company: string) => `${position} na ${company}`, 'pt');
+
+textResources.create('CVPDFExperiences.experienceHeader.experienceTime', (start_date: string, end_date: string) => {
+   const dateType = 'abbMonth-fullYear';
+   const startDate = dataViewString(new Date(start_date), dateType, 'en');
+   const endDate = dataViewString(new Date(end_date), dateType, 'en');
+
+   return `${startDate} to ${endDate}`;
+});
+textResources.create('CVPDFExperiences.experienceHeader.experienceTime', (start_date: string, end_date: string) => {
+   const dateType = 'abbMonth-fullYear';
+   const startDate = dataViewString(new Date(start_date), dateType, 'pt');
+   const endDate = dataViewString(new Date(end_date), dateType, 'pt');
+
+   return `${startDate} a ${endDate}`;
+}, 'pt');
+
+textResources.create('CVPDFExperiences.experienceHeader.timeDifference', (startDate: string, endDate: string) => {
+   const { year, month } = dateDiffYearMonth(startDate, endDate);
+   return `(${year} years and ${month} months)`;
+});
+textResources.create('CVPDFExperiences.experienceHeader.timeDifference', (startDate: string, endDate: string) => {
+   const { year, month } = dateDiffYearMonth(startDate, endDate);
+   return `(${year} anos e ${month} meses)`;
+}, 'pt');
 
 textResources.create('CVPDFExperiences.experiences.subtitle', 'Check below a summary of my work experience.');
 textResources.create('CVPDFExperiences.experiences.subtitle', 'Confira abaixo um resumo da minha experiência profissional.', 'pt');

--- a/src/components/content/curriculum/CVPDFTemplateContent/sections/CVPDFExperience.tsx
+++ b/src/components/content/curriculum/CVPDFTemplateContent/sections/CVPDFExperience.tsx
@@ -1,4 +1,4 @@
-import { Card, Container, DateView, Markdown } from '@/components/common';
+import { Card, Container, Markdown } from '@/components/common';
 import { useCVPDFTemplate } from '../CVPDFTemplateContext';
 import styles from '../CVPDFTemplateContent.module.scss';
 import { parseCSS } from '@/helpers/parse.helpers';
@@ -7,6 +7,9 @@ import { ContentSidebar } from '@/components/layout';
 import { Fragment } from 'react';
 import { useTextResources } from '@/services/TextResources/TextResourcesProvider';
 import texts from '../CVPDFTemplateContext.text';
+import Link from 'next/link';
+import { WatchLater, Web } from '@mui/icons-material';
+import { ExperienceData } from '@/types/database.types';
 
 export default function CVPDFExperiences(): React.ReactElement {
    const cv = useCVPDFTemplate();
@@ -14,6 +17,18 @@ export default function CVPDFExperiences(): React.ReactElement {
 
    const CSS = parseCSS('CVPDFExperiences', styles.CVPDFExperiences);
    const cardProps: CardProps = { elevation: 'none', padding: 'm' };
+
+   const experienceTitle = (experience: ExperienceData) => {
+      const position = experience.position || '';
+      const companyName = experience.company?.company_name || '';
+
+      if (!position || !companyName) {
+         console.warn('Experience position or company name is missing');
+         return '';
+      }
+
+      return textResources.getText('CVPDFExperiences.experienceHeader.title', position, companyName);
+   }
 
    return (
       <section className={CSS}>
@@ -30,8 +45,33 @@ export default function CVPDFExperiences(): React.ReactElement {
                   {cv.cv_experiences.map((experience, index) => (
                      <li key={index}>
                         <Card className={styles.experienceHeader} {...cardProps}>
-                           <h3>{experience.position} at {experience.company?.company_name}</h3>
-                           <p><DateView date={experience.start_date} /> - <DateView date={experience.end_date} /></p>
+                           <h3>{experienceTitle(experience)}</h3>
+
+                           <p className={styles.verticalAligned}>
+                              <WatchLater fontSize="small" />
+
+                              {textResources.getText(
+                                 'CVPDFExperiences.experienceHeader.experienceTime',
+                                 String(experience.start_date),
+                                 String(experience.end_date)
+                              )}
+                              {' '}
+                              {textResources.getText(
+                                 'CVPDFExperiences.experienceHeader.timeDifference',
+                                 String(experience.start_date),
+                                 String(experience.end_date)
+                              )}
+                           </p>
+
+                           <Link
+                              className={styles.verticalAligned}
+                              href={experience.company?.site_url}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                           >
+                              <Web fontSize="small" />
+                              {experience.company?.site_url}
+                           </Link>
 
                            <ul className={styles.chipsList}>
                               {experience.skills?.map((skill, index) => (
@@ -44,14 +84,14 @@ export default function CVPDFExperiences(): React.ReactElement {
                            <ContentSidebar breakpoint="m">
                               <Fragment>
                                  <h4>{textResources.getText('CVPDFExperiences.experiences.summary')}</h4>
-                                 <Markdown value={experience.summary} />
+                                 <Markdown className={styles.markdown} value={experience.summary} />
 
                                  <h4>{textResources.getText('CVPDFExperiences.experiences.description')}</h4>
-                                 <Markdown value={experience.description} />
+                                 <Markdown className={styles.markdown} value={experience.description} />
                               </Fragment>
                               <Fragment>
                                  <h4>{textResources.getText('CVPDFExperiences.experiences.responsibilities')}</h4>
-                                 <Markdown value={experience.responsibilities} />
+                                 <Markdown className={styles.markdown} value={experience.responsibilities} />
                               </Fragment>
                            </ContentSidebar>
                         </Card>

--- a/src/components/content/curriculum/CVPDFTemplateContent/sections/CVPDFHeader.tsx
+++ b/src/components/content/curriculum/CVPDFTemplateContent/sections/CVPDFHeader.tsx
@@ -10,6 +10,8 @@ import texts from '../CVPDFTemplateContext.text';
 export default function CVPDFHeader({ className }: { className?: string }): React.ReactElement {
    const cv = useCVPDFTemplate();
    const { textResources } = useTextResources(texts);
+   const whatsAppNumber = cv.user?.whatsapp_number?.replace(/[^0-9]/g, '');
+   const whatsAppLink = whatsAppNumber ? `https://wa.me/${whatsAppNumber}` : '#';
 
    const iconSize = 'small';
    const CSS = parseCSS(className, [
@@ -19,10 +21,11 @@ export default function CVPDFHeader({ className }: { className?: string }): Reac
 
    return (
       <header className={CSS}>
-         <Container className={styles.headerFlex} fullwidth>
+         <Container fullwidth>
             <div className={styles.headerInfo}>
                <h1>{cv.user?.first_name} {cv.user?.last_name}</h1>
                <p>{cv.job_title}</p>
+               <span>{textResources.getText('CVPDFHeader.header.experienceTime', String(cv.experience_time))}</span>
             </div>
             
             <Markdown
@@ -54,7 +57,7 @@ export default function CVPDFHeader({ className }: { className?: string }): Reac
                   </li>
                   <li>
                      <label><WhatsApp fontSize={iconSize} /></label>
-                     <Link href={`https://wa.me/${cv.user?.whatsapp_number}`}>{textResources.getText('CVPDFHeader.header.whatsapp')}</Link>
+                     <Link href={whatsAppLink}>{textResources.getText('CVPDFHeader.header.whatsapp')}</Link>
                   </li>
                </ul>
             </div>

--- a/src/components/forms/curriculums/CreateCurriculumForm/CreateCurriculumForm.text.ts
+++ b/src/components/forms/curriculums/CreateCurriculumForm/CreateCurriculumForm.text.ts
@@ -5,6 +5,12 @@ const textResources = new TextResources();
 textResources.create('CreateCurriculumForm.title.label', 'CV Title');
 textResources.create('CreateCurriculumForm.title.label', 'Título do CV', 'pt');
 
+textResources.create('CreateCurriculumForm.experienceTime.label', 'Experience Time');
+textResources.create('CreateCurriculumForm.experienceTime.label', 'Tempo de Experiência', 'pt');
+
+textResources.create('CreateCurriculumForm.experienceTime.placeholder', 'Enter your experience time in years');
+textResources.create('CreateCurriculumForm.experienceTime.placeholder', 'Digite seu tempo de experiência em anos', 'pt');
+
 textResources.create('CreateCurriculumForm.title.placeholder', 'Enter curriculum title');
 textResources.create('CreateCurriculumForm.title.placeholder', 'Digite o título do currículo', 'pt');
 

--- a/src/components/forms/curriculums/CreateCurriculumForm/CreateCurriculumForm.tsx
+++ b/src/components/forms/curriculums/CreateCurriculumForm/CreateCurriculumForm.tsx
@@ -60,6 +60,12 @@ export default function CreateCurriculumForm() {
                      placeholder={textResources.getText('CreateCurriculumForm.job_title.placeholder')}
                   />
                   <FormInput
+                     fieldName="experience_time"
+                     type="number"
+                     label={textResources.getText('CreateCurriculumForm.experienceTime.label')}
+                     placeholder={textResources.getText('CreateCurriculumForm.experienceTime.placeholder')}
+                  />
+                  <FormInput
                      fieldName="summary"
                      label={textResources.getText('CreateCurriculumForm.summary.label')}
                      placeholder={textResources.getText('CreateCurriculumForm.summary.placeholder')}

--- a/src/components/forms/curriculums/EditCVInfosForm/EditCVInfosForm.text.ts
+++ b/src/components/forms/curriculums/EditCVInfosForm/EditCVInfosForm.text.ts
@@ -10,6 +10,11 @@ textResources.create('EditCVInfosForm.field.title.label', 'Título do CV', 'pt')
 textResources.create('EditCVInfosForm.field.title.placeholder', 'Enter CV Title');
 textResources.create('EditCVInfosForm.field.title.placeholder', 'Digite o Título do CV', 'pt');
 
+textResources.create('EditCVInfosForm.field.experienceTime.label', 'Experience Time');
+textResources.create('EditCVInfosForm.field.experienceTime.label', 'Tempo de Experiência', 'pt');
+textResources.create('EditCVInfosForm.field.experienceTime.placeholder', 'Enter your experience time in years');
+textResources.create('EditCVInfosForm.field.experienceTime.placeholder', 'Digite seu tempo de experiência em anos', 'pt');
+
 textResources.create('EditCVInfosForm.field.notes.label', 'Reference Notes');
 textResources.create('EditCVInfosForm.field.notes.label', 'Notas de Referência', 'pt');
 textResources.create('EditCVInfosForm.field.notes.placeholder', 'Enter Reference Notes');

--- a/src/components/forms/curriculums/EditCVInfosForm/EditCVInfosForm.tsx
+++ b/src/components/forms/curriculums/EditCVInfosForm/EditCVInfosForm.tsx
@@ -40,6 +40,13 @@ export default function EditCVInfosForm() {
             placeholder={textResources.getText('EditCVInfosForm.field.title.placeholder')}
          />
          <FormInput
+            fieldName="experience_time"
+            label={textResources.getText('EditCVInfosForm.field.experienceTime.label')}
+            placeholder={textResources.getText('EditCVInfosForm.field.experienceTime.placeholder')}
+            type="number"
+            numberStep={0.1}
+         />
+         <FormInput
             fieldName="notes"
             label={textResources.getText('EditCVInfosForm.field.notes.label')}
             placeholder={textResources.getText('EditCVInfosForm.field.notes.placeholder')}

--- a/src/helpers/date.helpers.ts
+++ b/src/helpers/date.helpers.ts
@@ -1,0 +1,44 @@
+import { defaultLanguage } from '@/app.config';
+import { DateViewStringType } from '@/types/helpers.types';
+import dayjs from 'dayjs';
+
+export function dateDifference(startDate: Date, endDate: Date, unit: 'year' | 'month' | 'day'): number {
+   const _startDate = dayjs(startDate);
+   const _endDate = dayjs(endDate);
+
+   switch (unit) {
+      case 'year':
+         const years = _endDate.diff(_startDate, 'year');
+         return years;
+      case 'month':
+         const months = _endDate.diff(_startDate, 'month');
+         return months;
+      case 'day':
+         const days = _endDate.diff(_startDate, 'day');
+         return days;
+      default:
+         return 0;
+   }
+}
+
+export function dataViewString(date: Date, type: DateViewStringType = 'abbMonth-fullYear', locale: string = defaultLanguage): string {
+   if (!date) {
+      return '---';
+   }
+
+   switch (type) {
+      case 'locale-standard':
+         return dayjs(date).locale(locale).format('LL');
+      case 'abbMonth-fullYear':
+         return dayjs(date).locale(locale).format('MMM YYYY');
+      case 'fullMonth-fullYear':
+         return dayjs(date).locale(locale).format('MMMM YYYY');
+      case 'fullMonth-abbYear':
+         return dayjs(date).locale(locale).format('MMMM YY');
+      case 'abbMonth-abbYear':
+         return dayjs(date).locale(locale).format('MMM YY');
+      default:
+         console.warn(`Unknown date view type: ${type}`);
+         return '';
+   }
+};

--- a/src/hooks/Form/Form.types.ts
+++ b/src/hooks/Form/Form.types.ts
@@ -58,6 +58,7 @@ export interface FormInputProps extends FormBaseInputProps {
   minRows?: number;
   min?: number;
   max?: number;
+  numberStep?: number;
 }
 
 export interface FormSelectProps extends FormBaseInputProps {

--- a/src/hooks/Form/inputs/FormInput.tsx
+++ b/src/hooks/Form/inputs/FormInput.tsx
@@ -12,6 +12,7 @@ export default function FormInput({
    minRows = 5,
    min = 1,
    max = 10,
+   numberStep = 1,
    parseInput = (value: string | number) => value,
    onChange = () => {},
    ...props
@@ -45,7 +46,7 @@ export default function FormInput({
          multiline={multiline}
          minRows={minRows}
          onChange={handleChange}
-         {...(type === 'number' ? { inputProps: { min, max } } : {})}
+         {...(type === 'number' ? { inputProps: { min, max, step: numberStep } } : {})}
          {...props}
       />
    );

--- a/src/style/variables.scss
+++ b/src/style/variables.scss
@@ -1,9 +1,5 @@
 @use "sass:color";
 
-// $primary: #162a42;
-// $secondary: #ff8800;
-// $tertiary: #00e959;
-
 $primary: #006C67;
 $secondary: #0D1B2A;
 $tertiary: #8FE388;

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -63,6 +63,7 @@ export interface SkillSetData extends BasicData {
 
 export interface CVData extends CVSetData {
    title: string;
+   experience_time?: number;
    is_master: boolean;
    notes?: string;
    cv_experiences?: ExperienceData[];

--- a/src/types/helpers.types.ts
+++ b/src/types/helpers.types.ts
@@ -1,0 +1,1 @@
+export type DateViewStringType = 'locale-standard' | 'abbMonth-fullYear' | 'fullMonth-fullYear' | 'fullMonth-abbYear' | 'abbMonth-abbYear';


### PR DESCRIPTION
## [FRD-128] Description
This pull request introduces several enhancements and new features related to CV management, including support for experience time fields, improved date handling, and styling updates. The most significant changes are grouped into three categories: new features, styling improvements, and utility functions.

### New Features
* Added support for "Experience Time" fields in CV forms (`CreateCurriculumForm`, `EditCVInfosForm`) with labels and placeholders in both English and Portuguese.
* Introduced a new "Experience Time" section in the CV details view, displaying the experience time in years. 
* Enhanced the CV PDF template to include formatted experience time, time differences, and company website links. 

### Styling Improvements
* Adjusted font sizes for headers (`h4`, `h5`) and paragraphs in the CV PDF template for better readability.
* Added new styles for markdown content and experience-related elements in the CV PDF template. 

### Utility Functions
* Added `dateDifference` and `dataViewString` helper functions for calculating date differences and formatting dates in various styles
* Updated `FormInput` to support a customizable `numberStep` property for numeric inputs.