### PR TITLE
[FRD-135] Companies site URLs

### DIFF
--- a/src/components/content/curriculum/CVPDFTemplateContent/sections/CVPDFExperience.tsx
+++ b/src/components/content/curriculum/CVPDFTemplateContent/sections/CVPDFExperience.tsx
@@ -63,15 +63,17 @@ export default function CVPDFExperiences(): React.ReactElement {
                               )}
                            </p>
 
-                           <Link
-                              className={styles.verticalAligned}
-                              href={experience.company?.site_url}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                           >
-                              <Web fontSize="small" />
-                              {experience.company?.site_url}
-                           </Link>
+                           {experience.company?.site_url && (
+                              <Link
+                                 className={styles.verticalAligned}
+                                 href={experience.company?.site_url}
+                                 target="_blank"
+                                 rel="noopener noreferrer"
+                              >
+                                 <Web fontSize="small" />
+                                 {experience.company?.site_url}
+                              </Link>
+                           )}
 
                            <ul className={styles.chipsList}>
                               {experience.skills?.map((skill, index) => (


### PR DESCRIPTION
## [FRD-135] Description
This pull request introduces a small enhancement to the `CVPDFExperiences` component. The change conditionally displays the company website link only when a `site_url` is present in the experience data, improving the rendering logic.

* Added a conditional check to render the company website link only if `experience.company.site_url` exists in `CVPDFExperience.tsx`. [[1]](diffhunk://#diff-5cf965b2af3e3be563e273432ac2c3e129751eab9cc1f4f75899d12e5e64be68R66) [[2]](diffhunk://#diff-5cf965b2af3e3be563e273432ac2c3e129751eab9cc1f4f75899d12e5e64be68R76)

[FRD-135]: https://feliperamosdev.atlassian.net/browse/FRD-135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ