### PR TITLE
[FRD-137] Zero date difference prevent

### DIFF
--- a/src/components/content/HomeContent/sections/Experience/Experience.text.ts
+++ b/src/components/content/HomeContent/sections/Experience/Experience.text.ts
@@ -30,11 +30,17 @@ experienceText.create('Experience.item.experienceTime', (start_date: string, end
 
 experienceText.create('Experience.item.timeDifference', (startDate: string, endDate: string) => {
    const { year, month } = dateDiffYearMonth(startDate, endDate);
-   return `(${year} years and ${month} months)`;
+   const yearText = (year > 0) ? `${year} year${year > 1 ? 's' : ''}` : '';
+   const monthText = (month > 0) ? `${month} month${month > 1 ? 's' : ''}` : '';
+
+   return `(${[yearText, monthText].filter(Boolean).join(' and ')})`;
 });
 experienceText.create('Experience.item.timeDifference', (startDate: string, endDate: string) => {
    const { year, month } = dateDiffYearMonth(startDate, endDate);
-   return `(${year} anos e ${month} meses)`;
+   const yearText = (year > 0) ? `${year} ano${year > 1 ? 's' : ''}` : '';
+   const monthText = (month > 0) ? `${month} mês${month > 1 ? 'es' : ''}` : '';
+
+   return `(${[yearText, monthText].filter(Boolean).join(' e ')})`;
 }, 'pt');
 
 

--- a/src/components/content/curriculum/CVPDFTemplateContent/CVPDFTemplateContext.text.ts
+++ b/src/components/content/curriculum/CVPDFTemplateContent/CVPDFTemplateContext.text.ts
@@ -43,11 +43,17 @@ textResources.create('CVPDFExperiences.experienceHeader.experienceTime', (start_
 
 textResources.create('CVPDFExperiences.experienceHeader.timeDifference', (startDate: string, endDate: string) => {
    const { year, month } = dateDiffYearMonth(startDate, endDate);
-   return `(${year} years and ${month} months)`;
+   const yearText = (year > 0) ? `${year} year${year > 1 ? 's' : ''}` : '';
+   const monthText = (month > 0) ? `${month} month${month > 1 ? 's' : ''}` : '';
+
+   return `(${[yearText, monthText].filter(Boolean).join(' and ')})`;
 });
 textResources.create('CVPDFExperiences.experienceHeader.timeDifference', (startDate: string, endDate: string) => {
    const { year, month } = dateDiffYearMonth(startDate, endDate);
-   return `(${year} anos e ${month} meses)`;
+   const yearText = (year > 0) ? `${year} ano${year > 1 ? 's' : ''}` : '';
+   const monthText = (month > 0) ? `${month} mês${month > 1 ? 'es' : ''}` : '';
+
+   return `(${[yearText, monthText].filter(Boolean).join(' e ')})`;
 }, 'pt');
 
 textResources.create('CVPDFExperiences.experiences.subtitle', 'Check below a summary of my work experience.');


### PR DESCRIPTION
## [FRD-137] Description
This pull request improves how experience durations are displayed in both the home content and CV PDF sections. The formatting now omits zero-value years or months and correctly handles singular and plural forms in both English and Portuguese, resulting in clearer, more natural text.

**Formatting improvements for experience durations:**

* Updated the logic in `Experience.text.ts` and `CVPDFTemplateContext.text.ts` to only show non-zero years and months, and to use the correct singular or plural form for each language. For example, "1 year and 2 months" or "2 anos e 1 mês". [[1]](diffhunk://#diff-a05b125f8b24fa9f6d30d1019cdbac022dffebb31b0afb1c2149bbe35cd55f0eL33-R43) [[2]](diffhunk://#diff-8b98e09c1d5611b05cbca9e89f908008ca7d0c3e7f6cfd10efb22291d67139caL46-R56)

[FRD-137]: https://feliperamosdev.atlassian.net/browse/FRD-137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ