### PR TITLE
[FRD-141] Create Language - Page

### DIFF
--- a/src/app.config.ts
+++ b/src/app.config.ts
@@ -15,3 +15,11 @@ export const skillCategories = [
   { value: 'cloud', label: 'Cloud Services' },
   { value: 'others', label: 'Others' }
 ];
+
+export const languageLevels = [
+  { value: 'beginner', label: 'Beginner' },
+  { value: 'intermediate', label: 'Intermediate' },
+  { value: 'advanced', label: 'Advanced' },
+  { value: 'proficient', label: 'Proficient' },
+  { value: 'native', label: 'Native' }
+]

--- a/src/app.config.ts
+++ b/src/app.config.ts
@@ -22,4 +22,4 @@ export const languageLevels = [
   { value: 'advanced', label: 'Advanced' },
   { value: 'proficient', label: 'Proficient' },
   { value: 'native', label: 'Native' }
-]
+];

--- a/src/app/admin/language/create/page.tsx
+++ b/src/app/admin/language/create/page.tsx
@@ -1,0 +1,13 @@
+import LanguageCreateContent from "@/components/content/admin/language/LanguageCreateContent/LanguageCreateContent";
+import { AdminPageBase } from "@/components/layout";
+import { headersAcceptLanguage } from "@/helpers";
+
+export default async function LanguageCreatePage() {
+   const locale = await headersAcceptLanguage();
+
+   return (
+      <AdminPageBase language={locale}>
+         <LanguageCreateContent />
+      </AdminPageBase>
+   );
+}

--- a/src/components/content/admin/language/LanguageCreateContent/LanguageCreateContent.tsx
+++ b/src/components/content/admin/language/LanguageCreateContent/LanguageCreateContent.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+import CreateLanguageForm from "@/components/forms/languages/CreateLanguageForm/CreateLanguageForm";
+import { PageHeader } from "@/components/headers";
+
+export default function LanguageCreateContent() {
+   return (
+      <div className="LanguageCreateContent">
+         <PageHeader title="Create Language" description="Create a new language entry." />
+
+         <CreateLanguageForm />
+      </div>
+   );
+}

--- a/src/components/forms/languages/CreateLanguageForm/CreateLanguageForm.texts.ts
+++ b/src/components/forms/languages/CreateLanguageForm/CreateLanguageForm.texts.ts
@@ -1,0 +1,35 @@
+import { TextResources } from '@/services';
+
+const textResources = new TextResources();
+
+textResources.create('CreateLanguageForm.default_name.label', 'Default Name');
+textResources.create('CreateLanguageForm.default_name.label', 'Nome Padrão', 'pt');
+textResources.create('CreateLanguageForm.default_name.placeholder', 'Enter the default name. (Eg.: Portuguese)');
+textResources.create('CreateLanguageForm.default_name.placeholder', 'Insira o nome padrão. (Ex.: Portuguese)', 'pt');
+
+textResources.create('CreateLanguageForm.local_name.label', 'Local Name');
+textResources.create('CreateLanguageForm.local_name.label', 'Nome Local', 'pt');
+textResources.create('CreateLanguageForm.local_name.placeholder', 'Enter the local name. (Eg.: Português)');
+textResources.create('CreateLanguageForm.local_name.placeholder', 'Insira o nome local. (Ex.: Português)', 'pt');
+
+textResources.create('CreateLanguageForm.locale_code.label', 'Locale Code');
+textResources.create('CreateLanguageForm.locale_code.label', 'Código Local', 'pt');
+textResources.create('CreateLanguageForm.locale_code.placeholder', 'Enter the locale code. (Eg.: "en")');
+textResources.create('CreateLanguageForm.locale_code.placeholder', 'Insira o código local. (Ex.: "pt")', 'pt');
+
+textResources.create('CreateLanguageForm.reading_level.label', 'Reading Level');
+textResources.create('CreateLanguageForm.reading_level.label', 'Nível de Leitura', 'pt');
+
+textResources.create('CreateLanguageForm.writing_level.label', 'Writing Level');
+textResources.create('CreateLanguageForm.writing_level.label', 'Nível de Escrita', 'pt');
+
+textResources.create('CreateLanguageForm.speaking_level.label', 'Speaking Level');
+textResources.create('CreateLanguageForm.speaking_level.label', 'Nível de Fala', 'pt');
+
+textResources.create('CreateLanguageForm.listening_level.label', 'Listening Level');
+textResources.create('CreateLanguageForm.listening_level.label', 'Nível de Audição', 'pt');
+
+textResources.create('CreateLanguageForm.submit.label', 'Create Language');
+textResources.create('CreateLanguageForm.submit.label', 'Criar Idioma', 'pt');
+
+export default textResources;

--- a/src/components/forms/languages/CreateLanguageForm/CreateLanguageForm.tsx
+++ b/src/components/forms/languages/CreateLanguageForm/CreateLanguageForm.tsx
@@ -32,7 +32,7 @@ export default function CreateLanguageForm() {
 
          return created;
       } catch (error) {
-         throw error;
+         return error;
       }
    };
 

--- a/src/components/forms/languages/CreateLanguageForm/CreateLanguageForm.tsx
+++ b/src/components/forms/languages/CreateLanguageForm/CreateLanguageForm.tsx
@@ -1,0 +1,95 @@
+import { Form, FormInput, FormSelect, FormSubmit } from '@/hooks';
+import { useTextResources } from '@/services/TextResources/TextResourcesProvider';
+import texts from './CreateLanguageForm.texts'
+import { ContentSidebar } from '@/components/layout';
+import { Fragment } from 'react';
+import { Card, Container } from '@/components/common';
+import { CardProps } from '@/components/common/Card/Card.types';
+import { languageLevels } from '@/app.config';
+import { FormValues } from '@/hooks/Form/Form.types';
+import { useAjax } from '@/hooks/useAjax';
+import { LanguageData } from '@/types/database.types';
+import { useRouter } from 'next/navigation';
+
+export default function CreateLanguageForm() {
+   const { textResources } = useTextResources(texts);
+   const ajax = useAjax();
+   const router = useRouter();
+
+   const cardProps: CardProps = { padding: 'm' };
+
+   const handleSubmit = async (values: FormValues) => {
+      try {
+         const created = await ajax.post<LanguageData>('/language/create', values);
+
+         if (!created.success) {
+            throw created;
+         }
+
+         if (created.data?.id) {
+            router.push(`/admin/language/${created.data.id}`);
+         }
+
+         return created;
+      } catch (error) {
+         throw error;
+      }
+   };
+
+   return (
+      <Container>
+         <Form hideSubmit onSubmit={handleSubmit}>
+            <ContentSidebar>
+               <Fragment>
+                  <Card {...cardProps}>
+                     <FormInput
+                        fieldName="default_name"
+                        label={textResources.getText('CreateLanguageForm.default_name.label')}
+                        placeholder={textResources.getText('CreateLanguageForm.default_name.placeholder')}
+                     />
+                     <FormInput
+                        fieldName="local_name"
+                        label={textResources.getText('CreateLanguageForm.local_name.label')}
+                        placeholder={textResources.getText('CreateLanguageForm.local_name.placeholder')}
+                     />
+                     <FormInput
+                        fieldName="locale_code"
+                        label={textResources.getText('CreateLanguageForm.locale_code.label')}
+                        placeholder={textResources.getText('CreateLanguageForm.locale_code.placeholder')}
+                        max={2}
+                     />
+                  </Card>
+               </Fragment>
+
+               <Fragment>
+                  <Card {...cardProps}>
+                     <FormSelect
+                        fieldName="reading_level"
+                        label={textResources.getText('CreateLanguageForm.reading_level.label')}
+                        options={languageLevels}
+                     />
+                     <FormSelect
+                        fieldName="writing_level"
+                        label={textResources.getText('CreateLanguageForm.writing_level.label')}
+                        options={languageLevels}
+                     />
+                     <FormSelect
+                        fieldName="speaking_level"
+                        label={textResources.getText('CreateLanguageForm.speaking_level.label')}
+                        options={languageLevels}
+                     />
+                     <FormSelect
+                        fieldName="listening_level"
+                        label={textResources.getText('CreateLanguageForm.listening_level.label')}
+                        options={languageLevels}
+                     />
+                  </Card>
+                  <Card {...cardProps}>
+                     <FormSubmit label={textResources.getText('CreateLanguageForm.submit.label')} fullWidth />
+                  </Card>
+               </Fragment>
+            </ContentSidebar>
+         </Form>
+      </Container>
+   );
+}

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -81,3 +81,13 @@ export interface CVSetData extends BasicData {
    cv_id: number;
    user?: UserData;
 }
+
+export interface LanguageData extends BasicData {
+   default_name: string;
+   local_name: string;
+   locale_code: string;
+   reading_level: string;
+   writing_level: string;
+   speaking_level: string;
+   listening_level: string;
+}


### PR DESCRIPTION
## [FRD-141] Description
This pull request introduces a new feature to allow administrators to create language entries through the admin interface. It adds the necessary backend data type, form, UI components, and internationalized text resources to support the creation of language records, including specifying proficiency levels for different skills.

The most important changes are:

**Feature: Admin Language Creation**

* Added a new `LanguageCreatePage` (`src/app/admin/language/create/page.tsx`) that loads the user's locale and renders the language creation content.
* Implemented the `LanguageCreateContent` component, which displays the page header and the language creation form.
* Created the `CreateLanguageForm` component, which provides fields for default name, local name, locale code, and proficiency levels (reading, writing, speaking, listening), and handles form submission to the backend.

**Internationalization & Configuration**

* Added internationalized text resources for all form fields and labels in both English and Portuguese in `CreateLanguageForm.texts.ts`.
* Defined a new `languageLevels` array in `app.config.ts` to standardize selectable proficiency levels.

**Data Model**

* Introduced the `LanguageData` interface in `database.types.ts` to represent the structure of a language entry, including all relevant fields.

[FRD-141]: https://feliperamosdev.atlassian.net/browse/FRD-141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ