### PR TITLE
[FRD-142] Languages Widget

### DIFF
--- a/src/app/admin/language/create/page.tsx
+++ b/src/app/admin/language/create/page.tsx
@@ -1,6 +1,6 @@
-import LanguageCreateContent from "@/components/content/admin/language/LanguageCreateContent/LanguageCreateContent";
-import { AdminPageBase } from "@/components/layout";
-import { headersAcceptLanguage } from "@/helpers";
+import { LanguageCreateContent } from '@/components/content/admin/language';
+import { AdminPageBase } from '@/components/layout';
+import { headersAcceptLanguage } from '@/helpers';
 
 export default async function LanguageCreatePage() {
    const locale = await headersAcceptLanguage();

--- a/src/components/content/admin/DashboardContent/sections/DashboardSidebar/DashboardSidebar.tsx
+++ b/src/components/content/admin/DashboardContent/sections/DashboardSidebar/DashboardSidebar.tsx
@@ -1,8 +1,9 @@
-import { CompaniesWidget, SkillsWidget } from '@/components/widgets';
+import { CompaniesWidget, LanguagesWidget, SkillsWidget } from '@/components/widgets';
 
 export default function DashboardSidebar(): React.ReactElement {
    return (<>
       <SkillsWidget className="sidebar-item" />
       <CompaniesWidget className="sidebar-item" />
+      <LanguagesWidget className="sidebar-item" />
    </>);
 }

--- a/src/components/content/admin/language/LanguageCreateContent/LanguageCreateContent.tsx
+++ b/src/components/content/admin/language/LanguageCreateContent/LanguageCreateContent.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import CreateLanguageForm from "@/components/forms/languages/CreateLanguageForm/CreateLanguageForm";
-import { PageHeader } from "@/components/headers";
+import { CreateLanguageForm } from '@/components/forms/languages';
+import { PageHeader } from '@/components/headers';
 
 export default function LanguageCreateContent() {
    return (

--- a/src/components/content/admin/language/index.tsx
+++ b/src/components/content/admin/language/index.tsx
@@ -1,0 +1,1 @@
+export { default as LanguageCreateContent } from './LanguageCreateContent/LanguageCreateContent';

--- a/src/components/forms/languages/index.tsx
+++ b/src/components/forms/languages/index.tsx
@@ -1,0 +1,1 @@
+export { default as CreateLanguageForm } from './CreateLanguageForm/CreateLanguageForm';

--- a/src/components/widgets/LanguagesWidget/LanguagesWidget.texts.ts
+++ b/src/components/widgets/LanguagesWidget/LanguagesWidget.texts.ts
@@ -1,0 +1,11 @@
+import { TextResources } from "@/services";
+
+const textResources = new TextResources();
+
+textResources.create('LanguagesWidget.title', 'Languages');
+textResources.create('LanguagesWidget.title', 'Linguagens', 'pt');
+
+textResources.create('LanguagesWidget.addButton.title', 'Add Language');
+textResources.create('LanguagesWidget.addButton.title', 'Adicionar Idioma', 'pt');
+
+export default textResources;

--- a/src/components/widgets/LanguagesWidget/LanguagesWidget.tsx
+++ b/src/components/widgets/LanguagesWidget/LanguagesWidget.tsx
@@ -1,0 +1,83 @@
+import { WidgetHeader } from '@/components/headers';
+import { useTextResources } from '@/services/TextResources/TextResourcesProvider';
+import texts from './LanguagesWidget.texts'
+import { TableBase } from '@/components/common';
+import { LanguageWidgetProps } from './LanguagesWidget.types';
+import React, { useEffect, useRef, useState } from 'react';
+import { parseCSS } from '@/helpers/parse.helpers';
+import { useAjax } from '@/hooks/useAjax';
+import { LanguageData } from '@/types/database.types';
+import { useRouter } from 'next/navigation';
+import { RoundButton } from '@/components/buttons';
+import Link from 'next/link';
+import { Add } from '@mui/icons-material';
+
+export default function LanguagesWidget({ className, languages = [] }: LanguageWidgetProps) {
+   const [ loading, setLoading ] = useState<boolean>(true);
+   const [ langs, setLangs ] = useState<LanguageData[]>(languages);
+   const isReady = useRef<boolean>(false);
+   const { textResources } = useTextResources(texts);
+   const ajax = useAjax();
+   const router = useRouter();
+
+   const CSS = parseCSS(className, [
+      'LanguagesWidget'
+   ]);
+
+   useEffect(() => {
+      if (isReady.current) {
+         return;
+      }
+
+      isReady.current = true;
+      ajax.get<LanguageData[]>('/user/languages').then((response) => {
+         setLangs(response.data as LanguageData[]);
+      }).catch(err => {
+         console.error('Error fetching languages:', err);
+      }).finally(() => {
+         setLoading(false);
+      });
+   }, []);
+
+   return (
+      <div className={CSS}>
+         <WidgetHeader title={textResources.getText('LanguagesWidget.title')}>
+            <RoundButton
+               title={textResources.getText('LanguagesWidget.addButton.title')}
+               LinkComponent={Link}
+               color="primary"
+               href="/admin/language/create"
+            >
+               <Add />
+            </RoundButton>
+         </WidgetHeader>
+
+         <TableBase
+            hideHeader
+            items={langs}
+            loading={loading}
+            onClickRow={(item) => router.push(`/admin/language/${item.id}`)}
+            columnConfig={[
+               {
+                  propKey: 'local_name',
+                  label: '--'
+               },
+               {
+                  propKey: 'levels',
+                  label: '--',
+                  format: (_, item) => {
+                     const row = item as LanguageData;
+
+                     return <ul>
+                        <li>Reading: {row.reading_level}</li>
+                        <li>Writing: {row.writing_level}</li>
+                        <li>Speaking: {row.speaking_level}</li>
+                        <li>Listening: {row.listening_level}</li>
+                     </ul>;
+                  }
+               }
+            ]}
+         />
+      </div>
+   );
+}

--- a/src/components/widgets/LanguagesWidget/LanguagesWidget.types.ts
+++ b/src/components/widgets/LanguagesWidget/LanguagesWidget.types.ts
@@ -1,0 +1,6 @@
+import { LanguageData } from "@/types/database.types";
+
+export interface LanguageWidgetProps {
+   className?: string | string[];
+   languages?: LanguageData[];
+}

--- a/src/components/widgets/index.tsx
+++ b/src/components/widgets/index.tsx
@@ -2,3 +2,4 @@ export { default as ExperiencesWidget } from './ExperiencesWidget/ExperiencesWid
 export { default as CompaniesWidget } from './CompaniesWidget/CompaniesWidget';
 export { default as SkillsWidget } from './SkillsWidget/SkillsWidget';
 export { default as CVsWidget } from './CVsWidget/CVsWidget';
+export { default as LanguagesWidget } from './LanguagesWidget/LanguagesWidget';


### PR DESCRIPTION
## [FRD-142] Description
This pull request introduces a new `LanguagesWidget` to the admin dashboard, displaying user language data and allowing navigation to language creation. It also refactors several import/export statements for improved modularity and code organization.

**Feature addition:**

* Added a new `LanguagesWidget` component, which fetches and displays a list of user languages with proficiency levels, and includes an "Add Language" button linking to the language creation page. This widget is now included in the admin dashboard sidebar. [[1]](diffhunk://#diff-aa3439fcbaed8067efa4975b3fca772355ae52ee1ddc34c5b3c562bb69ca6233R1-R83) [[2]](diffhunk://#diff-2408e12cc3dfa28f1b1b8383d5f83a87a8e37809ea20303ca916748c70afb54aL1-R7) [[3]](diffhunk://#diff-bc6873f009768cbbcb5a6fbd93a43d5b2a9c045d19107352e285d4dfffb36028R1-R6) [[4]](diffhunk://#diff-0c02c2b6f4d9b39dffd68c6f40ac5fc2c7361acc0732b7c0b7eeddc459a37250R1-R11) [[5]](diffhunk://#diff-b6cf1a88169f705f6cebad9478a265c86451f669e93c435e7b2a068d80df9887R5)

**Code organization and modularity improvements:**

* Refactored imports and exports for `LanguageCreateContent` and `CreateLanguageForm` to use index files, simplifying and standardizing how these components are imported throughout the codebase. [[1]](diffhunk://#diff-307f661d937d3dfc31073ea830a1b7ce5dc2658cdc9c92aba5f74fdc55ad048eL1-R3) [[2]](diffhunk://#diff-ae135780148f5fa43299f888bd82683182109910cc46643a46ba5bc19dc7bfb7L3-R4) [[3]](diffhunk://#diff-bb925cde86f01e05ff62373c941eb28e479b60ae096db9f5137246234e59065aR1) [[4]](diffhunk://#diff-3aeb4b4358e3d46d198c7abc2529c1469fd7f4ae62c3890bab37984db8b7b954R1)

[FRD-142]: https://feliperamosdev.atlassian.net/browse/FRD-142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ