### PR TITLE
[FRD-144] Language Details - Edit

### DIFF
--- a/src/components/content/admin/language/LanguageDetailsContent/LanguageDetailsContent.tsx
+++ b/src/components/content/admin/language/LanguageDetailsContent/LanguageDetailsContent.tsx
@@ -6,12 +6,18 @@ import LanguageDetailsProvider from './LanguageDetailsContext';
 import { useTextResources } from '@/services/TextResources/TextResourcesProvider';
 import texts from './LanguageDetailsContent.texts';
 import { ContentSidebar, DataContainer } from '@/components/layout';
-import { Fragment } from 'react';
+import { Fragment, useState } from 'react';
 import { Card, Container } from '@/components/common';
 import { CardProps } from '@/components/common/Card/Card.types';
+import { EditButtons } from '@/components/buttons';
+import EditLanguageDetailsForm from '@/components/forms/languages/EditLanguageDetailsForm/EditLanguageDetailsForm';
+import EditLevelsForm from '@/components/forms/languages/EditLevelsForm/EditLevelsForm';
 
 export default function LanguageDetailsContent({ language }: LanguageDetailsContentProps) {
+   const [ detailsEdit, setDetailEdit ] = useState<boolean>(false);
+   const [ levelsEdit, setLevelsEdit ] = useState<boolean>(false);
    const { textResources } = useTextResources(texts);
+
    const cardProps: CardProps = { padding: 'm' };
 
    return (
@@ -27,43 +33,61 @@ export default function LanguageDetailsContent({ language }: LanguageDetailsCont
                   <Fragment>
                      <WidgetHeader
                         title={textResources.getText('LanguageDetails.detailsHeader.title')}
-                     />
+                     >
+                        <EditButtons
+                           editMode={detailsEdit}
+                           setEditMode={setDetailEdit}
+                        />
+                     </WidgetHeader>
 
                      <Card {...cardProps}>
-                        <DataContainer>
-                           <label>{textResources.getText('LanguageDetails.field.defaultName')}</label>
-                           <span>{language.default_name}</span>
-                        </DataContainer>
-                        <DataContainer>
-                           <label>{textResources.getText('LanguageDetails.field.localName')}</label>
-                           <span>{language.local_name}</span>
-                        </DataContainer>
-                        <DataContainer>
-                           <label>{textResources.getText('LanguageDetails.field.localeCode')}</label>
-                           <span>{language.locale_code}</span>
-                        </DataContainer>
+                        {detailsEdit && <EditLanguageDetailsForm />}
+                        {!detailsEdit && (
+                           <Fragment>
+                              <DataContainer>
+                                 <label>{textResources.getText('LanguageDetails.field.defaultName')}</label>
+                                 <span>{language.default_name}</span>
+                              </DataContainer>
+                              <DataContainer>
+                                 <label>{textResources.getText('LanguageDetails.field.localName')}</label>
+                                 <span>{language.local_name}</span>
+                              </DataContainer>
+                              <DataContainer>
+                                 <label>{textResources.getText('LanguageDetails.field.localeCode')}</label>
+                                 <span>{language.locale_code}</span>
+                              </DataContainer>
+                           </Fragment>
+                        )}
                      </Card>
 
-                     <WidgetHeader
-                        title={textResources.getText('LanguageDetails.levelsHeader.title')}
-                     />
+                     <WidgetHeader title={textResources.getText('LanguageDetails.levelsHeader.title')}>
+                        <EditButtons
+                           editMode={levelsEdit}
+                           setEditMode={setLevelsEdit}
+                        />
+                     </WidgetHeader>
                      <Card {...cardProps}>
-                        <DataContainer vertical>
-                           <label>{textResources.getText('LanguageDetails.field.readingLevel')}</label>
-                           <span>{language.reading_level}</span>
-                        </DataContainer>
-                        <DataContainer vertical>
-                           <label>{textResources.getText('LanguageDetails.field.writingLevel')}</label>
-                           <span>{language.writing_level}</span>
-                        </DataContainer>
-                        <DataContainer vertical>
-                           <label>{textResources.getText('LanguageDetails.field.speakingLevel')}</label>
-                           <span>{language.speaking_level}</span>
-                        </DataContainer>
-                        <DataContainer vertical>
-                           <label>{textResources.getText('LanguageDetails.field.listeningLevel')}</label>
-                           <span>{language.listening_level}</span>
-                        </DataContainer>
+                        {levelsEdit && <EditLevelsForm />}
+                        {!levelsEdit && (
+                           <Fragment>
+                              <DataContainer vertical>
+                                 <label>{textResources.getText('LanguageDetails.field.readingLevel')}</label>
+                                 <span>{language.reading_level}</span>
+                              </DataContainer>
+                              <DataContainer vertical>
+                                 <label>{textResources.getText('LanguageDetails.field.writingLevel')}</label>
+                                 <span>{language.writing_level}</span>
+                              </DataContainer>
+                              <DataContainer vertical>
+                                 <label>{textResources.getText('LanguageDetails.field.speakingLevel')}</label>
+                                 <span>{language.speaking_level}</span>
+                              </DataContainer>
+                              <DataContainer vertical>
+                                 <label>{textResources.getText('LanguageDetails.field.listeningLevel')}</label>
+                                 <span>{language.listening_level}</span>
+                              </DataContainer>
+                           </Fragment>
+                        )}
                      </Card>
                   </Fragment>
 

--- a/src/components/forms/languages/EditLanguageDetailsForm/EditLanguageDetailsForm.texts.ts
+++ b/src/components/forms/languages/EditLanguageDetailsForm/EditLanguageDetailsForm.texts.ts
@@ -1,0 +1,14 @@
+import { TextResources } from '@/services';
+
+const textResources = new TextResources();
+
+textResources.create('EditLanguageDetailsForm.default_name', 'Default Name');
+textResources.create('EditLanguageDetailsForm.default_name', 'Nome Padrão', 'pt');
+
+textResources.create('EditLanguageDetailsForm.local_name', 'Local Name');
+textResources.create('EditLanguageDetailsForm.local_name', 'Nome Local', 'pt');
+
+textResources.create('EditLanguageDetailsForm.locale_code', 'Locale Code');
+textResources.create('EditLanguageDetailsForm.locale_code', 'Código Local', 'pt');
+
+export default textResources;

--- a/src/components/forms/languages/EditLanguageDetailsForm/EditLanguageDetailsForm.tsx
+++ b/src/components/forms/languages/EditLanguageDetailsForm/EditLanguageDetailsForm.tsx
@@ -1,0 +1,36 @@
+import { useLanguageDetails } from '@/components/content/admin/language/LanguageDetailsContent/LanguageDetailsContext';
+import { Form, FormInput } from '@/hooks';
+import { FormValues } from '@/hooks/Form/Form.types';
+import { useAjax } from '@/hooks/useAjax';
+import { useTextResources } from '@/services/TextResources/TextResourcesProvider';
+import { LanguageData } from '@/types/database.types';
+import texts from './EditLanguageDetailsForm.texts';
+
+export default function EditLanguageDetailsForm() {
+   const { textResources } = useTextResources(texts);
+   const language = useLanguageDetails();
+   const ajax = useAjax();
+
+   const handleUpdate = async (values: FormValues) => {
+      try {
+         const updated = await ajax.patch<LanguageData>('/language/update', values);
+
+         if (!updated.success) {
+            throw updated;
+         }
+
+         window.location.reload();
+         return updated.data;
+      } catch (error) {
+         return error;
+      }
+   };
+
+   return (
+      <Form initialValues={{...language}} editMode onSubmit={handleUpdate}>
+         <FormInput fieldName="default_name" label={textResources.getText('EditLanguageDetailsForm.default_name')} />
+         <FormInput fieldName="local_name" label={textResources.getText('EditLanguageDetailsForm.local_name')} />
+         <FormInput fieldName="locale_code" label={textResources.getText('EditLanguageDetailsForm.locale_code')} />
+      </Form>
+   );
+}

--- a/src/components/forms/languages/EditLevelsForm/EditLevelsForm.texts.ts
+++ b/src/components/forms/languages/EditLevelsForm/EditLevelsForm.texts.ts
@@ -1,0 +1,17 @@
+import { TextResources } from '@/services';
+
+const textResources = new TextResources();
+
+textResources.create('EditLevelsForm.reading_level', 'Reading');
+textResources.create('EditLevelsForm.reading_level', 'Leitura', 'pt');
+
+textResources.create('EditLevelsForm.writing_level', 'Writing');
+textResources.create('EditLevelsForm.writing_level', 'Escrita', 'pt');
+
+textResources.create('EditLevelsForm.speaking_level', 'Speaking');
+textResources.create('EditLevelsForm.speaking_level', 'Fala', 'pt');
+
+textResources.create('EditLevelsForm.listening_level', 'Listening');
+textResources.create('EditLevelsForm.listening_level', 'Audição', 'pt');
+
+export default textResources;

--- a/src/components/forms/languages/EditLevelsForm/EditLevelsForm.tsx
+++ b/src/components/forms/languages/EditLevelsForm/EditLevelsForm.tsx
@@ -1,0 +1,53 @@
+import { useLanguageDetails } from '@/components/content/admin/language/LanguageDetailsContent/LanguageDetailsContext';
+import { Form, FormSelect } from '@/hooks';
+import { useTextResources } from '@/services/TextResources/TextResourcesProvider';
+import texts from './EditLevelsForm.texts';
+import { languageLevels } from '@/app.config';
+import { FormValues } from '@/hooks/Form/Form.types';
+import { useAjax } from '@/hooks/useAjax';
+import { LanguageData } from '@/types/database.types';
+
+export default function EditLevelsForm() {
+   const language = useLanguageDetails();
+   const { textResources } = useTextResources(texts);
+   const ajax = useAjax();
+
+   const handleUpdate = async (values: FormValues) => {
+      try {
+         const updated = await ajax.patch<LanguageData>('/language/update', { language_id: language.id, updates: values });
+         if (!updated.success) {
+            throw updated;
+         }
+
+         window.location.reload();
+         return updated;
+      } catch (error) {
+         return error;
+      }
+   }
+
+   return (
+      <Form initialValues={{...language}} onSubmit={handleUpdate} editMode>
+         <FormSelect
+            fieldName="reading_level"
+            label={textResources.getText('EditLevelsForm.reading_level')}
+            options={languageLevels}
+         />
+         <FormSelect
+            fieldName="writing_level"
+            label={textResources.getText('EditLevelsForm.writing_level')}
+            options={languageLevels}
+         />
+         <FormSelect
+            fieldName="speaking_level"
+            label={textResources.getText('EditLevelsForm.speaking_level')}
+            options={languageLevels}
+         />
+         <FormSelect
+            fieldName="listening_level"
+            label={textResources.getText('EditLevelsForm.listening_level')}
+            options={languageLevels}
+         />
+      </Form>
+   );
+}


### PR DESCRIPTION
## [FRD-144] Description
This pull request adds in-place editing functionality to the language details admin page, allowing users to edit both general language details and proficiency levels directly from the UI. It introduces two new forms—one for editing language details and one for editing language levels—each with their own localized text resources. The main content component is updated to toggle between display and edit modes for each section.

**Feature: In-place editing for language details and levels**

- Added local state and edit mode toggles to `LanguageDetailsContent` to allow switching between view and edit modes for both language details and levels. [[1]](diffhunk://#diff-7cfba55ac2cf03d76c0e1c882f4bf14c5235ffbaea58a12c21a43095a1b2152fL9-R20) [[2]](diffhunk://#diff-7cfba55ac2cf03d76c0e1c882f4bf14c5235ffbaea58a12c21a43095a1b2152fR36-R46) [[3]](diffhunk://#diff-7cfba55ac2cf03d76c0e1c882f4bf14c5235ffbaea58a12c21a43095a1b2152fR59-R72) [[4]](diffhunk://#diff-7cfba55ac2cf03d76c0e1c882f4bf14c5235ffbaea58a12c21a43095a1b2152fR89-R90)
- Integrated `EditLanguageDetailsForm` and `EditLevelsForm` components into the language details page, displaying the appropriate form when edit mode is active for each section. [[1]](diffhunk://#diff-7cfba55ac2cf03d76c0e1c882f4bf14c5235ffbaea58a12c21a43095a1b2152fR36-R46) [[2]](diffhunk://#diff-7cfba55ac2cf03d76c0e1c882f4bf14c5235ffbaea58a12c21a43095a1b2152fR59-R72) [[3]](diffhunk://#diff-7cfba55ac2cf03d76c0e1c882f4bf14c5235ffbaea58a12c21a43095a1b2152fR89-R90)

**New forms for editing**

- Created `EditLanguageDetailsForm` to handle editing of language name and locale fields, including form submission logic and localized labels. [[1]](diffhunk://#diff-61bd4b46055e0114b1f179c97fb2621df96a75998dd34a7b4dbe42a33c810837R1-R36) [[2]](diffhunk://#diff-bab2d9de8056cfa8bac6e06f34459c8409e9ab06538e9eafac373298fb363639R1-R14)
- Created `EditLevelsForm` to handle editing of reading, writing, speaking, and listening levels with select options and localized labels. [[1]](diffhunk://#diff-d331e50e60cf739fd5c8ae87894e2401628ce23b8d09783e39ae50690df43639R1-R53) [[2]](diffhunk://#diff-cefb669837b0a1f557938df0b71b56ab37a7c75c9d8b3d890163f54634065396R1-R17)

**Localization**

- Added new localized text resources for all fields in both edit forms, supporting English and Portuguese. [[1]](diffhunk://#diff-bab2d9de8056cfa8bac6e06f34459c8409e9ab06538e9eafac373298fb363639R1-R14) [[2]](diffhunk://#diff-cefb669837b0a1f557938df0b71b56ab37a7c75c9d8b3d890163f54634065396R1-R17)