### PR TITLE
[FRD-145] Language Delete

### DIFF
--- a/src/components/content/admin/language/LanguageDetailsContent/LanguageDetailsContent.texts.ts
+++ b/src/components/content/admin/language/LanguageDetailsContent/LanguageDetailsContent.texts.ts
@@ -44,4 +44,7 @@ textResources.create('LanguageDetails.detailsHeader.title', 'Detalhes do Idioma'
 textResources.create('LanguageDetails.levelsHeader.title', 'Proficiency Levels');
 textResources.create('LanguageDetails.levelsHeader.title', 'Níveis de Proficiência', 'pt');
 
+textResources.create('LanguageDetails.deleteConfirm', 'Are you sure you want to delete this language? This action cannot be undone.');
+textResources.create('LanguageDetails.deleteConfirm', 'Tem certeza de que deseja excluir este idioma? Esta ação não pode ser desfeita.', 'pt');
+
 export default textResources;

--- a/src/components/content/admin/language/LanguageDetailsContent/LanguageDetailsContent.tsx
+++ b/src/components/content/admin/language/LanguageDetailsContent/LanguageDetailsContent.tsx
@@ -12,13 +12,37 @@ import { CardProps } from '@/components/common/Card/Card.types';
 import { EditButtons } from '@/components/buttons';
 import EditLanguageDetailsForm from '@/components/forms/languages/EditLanguageDetailsForm/EditLanguageDetailsForm';
 import EditLevelsForm from '@/components/forms/languages/EditLevelsForm/EditLevelsForm';
+import { Form, FormSubmit } from '@/hooks';
+import { Delete } from '@mui/icons-material';
+import { useAjax } from '@/hooks/useAjax';
+import { useRouter } from 'next/navigation';
 
 export default function LanguageDetailsContent({ language }: LanguageDetailsContentProps) {
    const [ detailsEdit, setDetailEdit ] = useState<boolean>(false);
    const [ levelsEdit, setLevelsEdit ] = useState<boolean>(false);
    const { textResources } = useTextResources(texts);
+   const ajax = useAjax();
+   const router = useRouter();
 
    const cardProps: CardProps = { padding: 'm' };
+
+   const handleDelete = async () => {
+      if (!window.confirm(textResources.getText('LanguageDetails.deleteConfirm'))) {
+         return;
+      }
+
+      try {
+         const response = await ajax.delete('/language/delete', { data: { language_id: language.id } });
+         if (!response.success) {
+            throw response;
+         }
+
+         router.push('/admin');
+         return response;
+      } catch (error) {
+         console.error('Error deleting language:', error);
+      }
+   };
 
    return (
       <LanguageDetailsProvider language={language}>
@@ -106,6 +130,12 @@ export default function LanguageDetailsContent({ language }: LanguageDetailsCont
                            {language.updated_at && <span>{new Date(language.updated_at).toLocaleString()}</span>}
                            {!language.updated_at && <span>--</span>}
                         </DataContainer>
+                     </Card>
+
+                     <Card {...cardProps}>
+                        <Form hideSubmit onSubmit={handleDelete}>
+                           <FormSubmit color="error" fullWidth label="Delete Language" startIcon={<Delete />} />
+                        </Form>
                      </Card>
                   </Fragment>
                </ContentSidebar>


### PR DESCRIPTION
## [FRD-145] Description
This pull request adds a language deletion feature to the admin language details page. It introduces a delete button with confirmation, integrates backend deletion via AJAX, and includes localized confirmation text for both English and Portuguese.

**Feature: Language Deletion**

* Added a delete button to the `LanguageDetailsContent` component, allowing admins to delete a language. The button triggers a confirmation dialog and, upon confirmation, sends a delete request to the backend and redirects to the admin page if successful. [[1]](diffhunk://#diff-7cfba55ac2cf03d76c0e1c882f4bf14c5235ffbaea58a12c21a43095a1b2152fR15-R46) [[2]](diffhunk://#diff-7cfba55ac2cf03d76c0e1c882f4bf14c5235ffbaea58a12c21a43095a1b2152fR134-R139)

**Localization**

* Added new localized text resources for the delete confirmation dialog in both English and Portuguese in `LanguageDetailsContent.texts.ts`.

[FRD-145]: https://feliperamosdev.atlassian.net/browse/FRD-145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ