### PR TITLE
[FRD-140] Spoken Languages Features

### DIFF
--- a/src/app.config.ts
+++ b/src/app.config.ts
@@ -15,3 +15,11 @@ export const skillCategories = [
   { value: 'cloud', label: 'Cloud Services' },
   { value: 'others', label: 'Others' }
 ];
+
+export const languageLevels = [
+  { value: 'beginner', label: 'Beginner' },
+  { value: 'intermediate', label: 'Intermediate' },
+  { value: 'advanced', label: 'Advanced' },
+  { value: 'proficient', label: 'Proficient' },
+  { value: 'native', label: 'Native' }
+];

--- a/src/app/admin/language/[language_id]/page.tsx
+++ b/src/app/admin/language/[language_id]/page.tsx
@@ -1,0 +1,29 @@
+import { ErrorContent } from '@/components/content';
+import LanguageDetailsContent from '@/components/content/admin/language/LanguageDetailsContent/LanguageDetailsContent';
+import { ErrorContentProps } from '@/components/content/ErrorContent/ErrorContent.types';
+import { AdminPageBase } from '@/components/layout';
+import { headersAcceptLanguage } from '@/helpers';
+import { useAjax } from '@/hooks/useAjax';
+import { LanguageData } from '@/types/database.types';
+
+export default async function LanguageDetailsPage({ params }: { params: Promise<{ language_id: string }> }) {
+   const { language_id } = await params;
+   const locale = await headersAcceptLanguage();
+   const ajax = useAjax();
+
+   try {
+      const language = await ajax.get<LanguageData>(`/language/${language_id}`);
+
+      if (language.error) {
+         return <ErrorContent {...language as ErrorContentProps} />;
+      }
+
+      return (
+         <AdminPageBase language={locale}>
+            <LanguageDetailsContent language={language.data as LanguageData} />
+         </AdminPageBase>
+      );
+   } catch (error) {
+      return <ErrorContent {...error as ErrorContentProps} />
+   }
+}

--- a/src/app/admin/language/[language_id]/page.tsx
+++ b/src/app/admin/language/[language_id]/page.tsx
@@ -3,13 +3,12 @@ import LanguageDetailsContent from '@/components/content/admin/language/Language
 import { ErrorContentProps } from '@/components/content/ErrorContent/ErrorContent.types';
 import { AdminPageBase } from '@/components/layout';
 import { headersAcceptLanguage } from '@/helpers';
-import { useAjax } from '@/hooks/useAjax';
 import { LanguageData } from '@/types/database.types';
+import ajax from '@/hooks/useAjax';
 
 export default async function LanguageDetailsPage({ params }: { params: Promise<{ language_id: string }> }) {
    const { language_id } = await params;
    const locale = await headersAcceptLanguage();
-   const ajax = useAjax();
 
    try {
       const language = await ajax.get<LanguageData>(`/language/${language_id}`);

--- a/src/app/admin/language/[language_id]/page.tsx
+++ b/src/app/admin/language/[language_id]/page.tsx
@@ -14,7 +14,7 @@ export default async function LanguageDetailsPage({ params }: { params: Promise<
    try {
       const language = await ajax.get<LanguageData>(`/language/${language_id}`);
 
-      if (language.error) {
+      if (!language.success) {
          return <ErrorContent {...language as ErrorContentProps} />;
       }
 

--- a/src/app/admin/language/create/page.tsx
+++ b/src/app/admin/language/create/page.tsx
@@ -1,6 +1,6 @@
-import LanguageCreateContent from "@/components/content/admin/language/LanguageCreateContent/LanguageCreateContent";
-import { AdminPageBase } from "@/components/layout";
-import { headersAcceptLanguage } from "@/helpers";
+import { LanguageCreateContent } from '@/components/content/admin/language';
+import { AdminPageBase } from '@/components/layout';
+import { headersAcceptLanguage } from '@/helpers';
 
 export default async function LanguageCreatePage() {
    const locale = await headersAcceptLanguage();

--- a/src/app/admin/language/create/page.tsx
+++ b/src/app/admin/language/create/page.tsx
@@ -1,0 +1,13 @@
+import LanguageCreateContent from "@/components/content/admin/language/LanguageCreateContent/LanguageCreateContent";
+import { AdminPageBase } from "@/components/layout";
+import { headersAcceptLanguage } from "@/helpers";
+
+export default async function LanguageCreatePage() {
+   const locale = await headersAcceptLanguage();
+
+   return (
+      <AdminPageBase language={locale}>
+         <LanguageCreateContent />
+      </AdminPageBase>
+   );
+}

--- a/src/components/content/admin/DashboardContent/sections/DashboardSidebar/DashboardSidebar.tsx
+++ b/src/components/content/admin/DashboardContent/sections/DashboardSidebar/DashboardSidebar.tsx
@@ -1,8 +1,9 @@
-import { CompaniesWidget, SkillsWidget } from '@/components/widgets';
+import { CompaniesWidget, LanguagesWidget, SkillsWidget } from '@/components/widgets';
 
 export default function DashboardSidebar(): React.ReactElement {
    return (<>
       <SkillsWidget className="sidebar-item" />
       <CompaniesWidget className="sidebar-item" />
+      <LanguagesWidget className="sidebar-item" />
    </>);
 }

--- a/src/components/content/admin/language/LanguageCreateContent/LanguageCreateContent.texts.ts
+++ b/src/components/content/admin/language/LanguageCreateContent/LanguageCreateContent.texts.ts
@@ -1,0 +1,12 @@
+import { TextResources } from '@/services';
+
+const textResources = new TextResources();
+textResources.create('LanguageCreateContent.pageHeader.title', 'Create Language');
+textResources.create('LanguageCreateContent.pageHeader.title', 'Criar Idioma', 'pt');
+
+textResources.create('LanguageCreateContent.pageHeader.description', 'Fill in the details to create a new language.');
+textResources.create('LanguageCreateContent.pageHeader.description', 'Preencha os detalhes para criar um novo idioma.', 'pt');
+
+export default textResources;
+
+

--- a/src/components/content/admin/language/LanguageCreateContent/LanguageCreateContent.tsx
+++ b/src/components/content/admin/language/LanguageCreateContent/LanguageCreateContent.tsx
@@ -2,11 +2,18 @@
 
 import { CreateLanguageForm } from '@/components/forms/languages';
 import { PageHeader } from '@/components/headers';
+import { useTextResources } from '@/services/TextResources/TextResourcesProvider';
+import texts from './LanguageCreateContent.texts';
 
 export default function LanguageCreateContent() {
+   const { textResources } = useTextResources(texts);
+
    return (
       <div className="LanguageCreateContent">
-         <PageHeader title="Create Language" description="Create a new language entry." />
+         <PageHeader
+            title={textResources.getText('LanguageCreateContent.pageHeader.title')}
+            description={textResources.getText('LanguageCreateContent.pageHeader.description')}
+         />
 
          <CreateLanguageForm />
       </div>

--- a/src/components/content/admin/language/LanguageCreateContent/LanguageCreateContent.tsx
+++ b/src/components/content/admin/language/LanguageCreateContent/LanguageCreateContent.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+import CreateLanguageForm from "@/components/forms/languages/CreateLanguageForm/CreateLanguageForm";
+import { PageHeader } from "@/components/headers";
+
+export default function LanguageCreateContent() {
+   return (
+      <div className="LanguageCreateContent">
+         <PageHeader title="Create Language" description="Create a new language entry." />
+
+         <CreateLanguageForm />
+      </div>
+   );
+}

--- a/src/components/content/admin/language/LanguageCreateContent/LanguageCreateContent.tsx
+++ b/src/components/content/admin/language/LanguageCreateContent/LanguageCreateContent.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import CreateLanguageForm from "@/components/forms/languages/CreateLanguageForm/CreateLanguageForm";
-import { PageHeader } from "@/components/headers";
+import { CreateLanguageForm } from '@/components/forms/languages';
+import { PageHeader } from '@/components/headers';
 
 export default function LanguageCreateContent() {
    return (

--- a/src/components/content/admin/language/LanguageDetailsContent/LanguageDetailsContent.texts.ts
+++ b/src/components/content/admin/language/LanguageDetailsContent/LanguageDetailsContent.texts.ts
@@ -1,0 +1,47 @@
+import { TextResources } from '@/services';
+
+const textResources = new TextResources();
+
+textResources.create('LanguageDetails.headerTitle', 'Language Details');
+textResources.create('LanguageDetails.headerTitle', 'Idioma Detalhes', 'pt');
+
+textResources.create('LanguageDetails.headerDescription', 'Manage the details of the language');
+textResources.create('LanguageDetails.headerDescription', 'Gerenciar os detalhes do idioma', 'pt');
+
+textResources.create('LanguageDetails.field.id', 'ID');
+textResources.create('LanguageDetails.field.id', 'ID', 'pt');
+
+textResources.create('LanguageDetails.field.createdAt', 'Created At');
+textResources.create('LanguageDetails.field.createdAt', 'Criado Em', 'pt');
+
+textResources.create('LanguageDetails.field.updatedAt', 'Updated At');
+textResources.create('LanguageDetails.field.updatedAt', 'Atualizado Em', 'pt');
+
+textResources.create('LanguageDetails.field.defaultName', 'Default Name');
+textResources.create('LanguageDetails.field.defaultName', 'Nome Padrão', 'pt');
+
+textResources.create('LanguageDetails.field.localName', 'Local Name');
+textResources.create('LanguageDetails.field.localName', 'Nome Local', 'pt');
+
+textResources.create('LanguageDetails.field.localeCode', 'Locale Code');
+textResources.create('LanguageDetails.field.localeCode', 'Código do Idioma', 'pt');
+
+textResources.create('LanguageDetails.field.readingLevel', 'Reading');
+textResources.create('LanguageDetails.field.readingLevel', 'Nível de Leitura', 'pt');
+
+textResources.create('LanguageDetails.field.writingLevel', 'Writing');
+textResources.create('LanguageDetails.field.writingLevel', 'Nível de Escrita', 'pt');
+
+textResources.create('LanguageDetails.field.speakingLevel', 'Speaking');
+textResources.create('LanguageDetails.field.speakingLevel', 'Nível de Fala', 'pt');
+
+textResources.create('LanguageDetails.field.listeningLevel', 'Listening');
+textResources.create('LanguageDetails.field.listeningLevel', 'Nível de Audição', 'pt');
+
+textResources.create('LanguageDetails.detailsHeader.title', 'Language Details');
+textResources.create('LanguageDetails.detailsHeader.title', 'Detalhes do Idioma', 'pt');
+
+textResources.create('LanguageDetails.levelsHeader.title', 'Proficiency Levels');
+textResources.create('LanguageDetails.levelsHeader.title', 'Níveis de Proficiência', 'pt');
+
+export default textResources;

--- a/src/components/content/admin/language/LanguageDetailsContent/LanguageDetailsContent.texts.ts
+++ b/src/components/content/admin/language/LanguageDetailsContent/LanguageDetailsContent.texts.ts
@@ -44,4 +44,7 @@ textResources.create('LanguageDetails.detailsHeader.title', 'Detalhes do Idioma'
 textResources.create('LanguageDetails.levelsHeader.title', 'Proficiency Levels');
 textResources.create('LanguageDetails.levelsHeader.title', 'Níveis de Proficiência', 'pt');
 
+textResources.create('LanguageDetails.deleteConfirm', 'Are you sure you want to delete this language? This action cannot be undone.');
+textResources.create('LanguageDetails.deleteConfirm', 'Tem certeza de que deseja excluir este idioma? Esta ação não pode ser desfeita.', 'pt');
+
 export default textResources;

--- a/src/components/content/admin/language/LanguageDetailsContent/LanguageDetailsContent.tsx
+++ b/src/components/content/admin/language/LanguageDetailsContent/LanguageDetailsContent.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { PageHeader, WidgetHeader } from '@/components/headers';
+import { LanguageDetailsContentProps } from './LanguageDetailsContent.types';
+import LanguageDetailsProvider from './LanguageDetailsContext';
+import { useTextResources } from '@/services/TextResources/TextResourcesProvider';
+import texts from './LanguageDetailsContent.texts';
+import { ContentSidebar, DataContainer } from '@/components/layout';
+import { Fragment } from 'react';
+import { Card, Container } from '@/components/common';
+import { CardProps } from '@/components/common/Card/Card.types';
+
+export default function LanguageDetailsContent({ language }: LanguageDetailsContentProps) {
+   const { textResources } = useTextResources(texts);
+   const cardProps: CardProps = { padding: 'm' };
+
+   return (
+      <LanguageDetailsProvider language={language}>
+         <div className="LanguageDetailsContent">
+            <PageHeader
+               title={textResources.getText('LanguageDetails.headerTitle')}
+               description={textResources.getText('LanguageDetails.headerDescription')}
+            />
+
+            <Container>
+               <ContentSidebar>
+                  <Fragment>
+                     <WidgetHeader
+                        title={textResources.getText('LanguageDetails.detailsHeader.title')}
+                     />
+
+                     <Card {...cardProps}>
+                        <DataContainer>
+                           <label>{textResources.getText('LanguageDetails.field.defaultName')}</label>
+                           <span>{language.default_name}</span>
+                        </DataContainer>
+                        <DataContainer>
+                           <label>{textResources.getText('LanguageDetails.field.localName')}</label>
+                           <span>{language.local_name}</span>
+                        </DataContainer>
+                        <DataContainer>
+                           <label>{textResources.getText('LanguageDetails.field.localeCode')}</label>
+                           <span>{language.locale_code}</span>
+                        </DataContainer>
+                     </Card>
+
+                     <WidgetHeader
+                        title={textResources.getText('LanguageDetails.levelsHeader.title')}
+                     />
+                     <Card {...cardProps}>
+                        <DataContainer vertical>
+                           <label>{textResources.getText('LanguageDetails.field.readingLevel')}</label>
+                           <span>{language.reading_level}</span>
+                        </DataContainer>
+                        <DataContainer vertical>
+                           <label>{textResources.getText('LanguageDetails.field.writingLevel')}</label>
+                           <span>{language.writing_level}</span>
+                        </DataContainer>
+                        <DataContainer vertical>
+                           <label>{textResources.getText('LanguageDetails.field.speakingLevel')}</label>
+                           <span>{language.speaking_level}</span>
+                        </DataContainer>
+                        <DataContainer vertical>
+                           <label>{textResources.getText('LanguageDetails.field.listeningLevel')}</label>
+                           <span>{language.listening_level}</span>
+                        </DataContainer>
+                     </Card>
+                  </Fragment>
+
+                  <Fragment>
+                     <Card {...cardProps}>
+                        <DataContainer>
+                           <label>{textResources.getText('LanguageDetails.field.id')}</label>
+                           <span>{language.id}</span>
+                        </DataContainer>
+                        <DataContainer vertical>
+                           <label>{textResources.getText('LanguageDetails.field.createdAt')}</label>
+                           <span>{new Date(language.created_at).toLocaleString()}</span>
+                        </DataContainer>
+                        <DataContainer vertical>
+                           <label>{textResources.getText('LanguageDetails.field.updatedAt')}</label>
+                           {language.updated_at && <span>{new Date(language.updated_at).toLocaleString()}</span>}
+                           {!language.updated_at && <span>--</span>}
+                        </DataContainer>
+                     </Card>
+                  </Fragment>
+               </ContentSidebar>
+            </Container>
+         </div>
+      </LanguageDetailsProvider>
+   );
+}

--- a/src/components/content/admin/language/LanguageDetailsContent/LanguageDetailsContent.tsx
+++ b/src/components/content/admin/language/LanguageDetailsContent/LanguageDetailsContent.tsx
@@ -12,13 +12,37 @@ import { CardProps } from '@/components/common/Card/Card.types';
 import { EditButtons } from '@/components/buttons';
 import EditLanguageDetailsForm from '@/components/forms/languages/EditLanguageDetailsForm/EditLanguageDetailsForm';
 import EditLevelsForm from '@/components/forms/languages/EditLevelsForm/EditLevelsForm';
+import { Form, FormSubmit } from '@/hooks';
+import { Delete } from '@mui/icons-material';
+import { useAjax } from '@/hooks/useAjax';
+import { useRouter } from 'next/navigation';
 
 export default function LanguageDetailsContent({ language }: LanguageDetailsContentProps) {
    const [ detailsEdit, setDetailEdit ] = useState<boolean>(false);
    const [ levelsEdit, setLevelsEdit ] = useState<boolean>(false);
    const { textResources } = useTextResources(texts);
+   const ajax = useAjax();
+   const router = useRouter();
 
    const cardProps: CardProps = { padding: 'm' };
+
+   const handleDelete = async () => {
+      if (!window.confirm(textResources.getText('LanguageDetails.deleteConfirm'))) {
+         return;
+      }
+
+      try {
+         const response = await ajax.delete('/language/delete', { data: { language_id: language.id } });
+         if (!response.success) {
+            throw response;
+         }
+
+         router.push('/admin');
+         return response;
+      } catch (error) {
+         console.error('Error deleting language:', error);
+      }
+   };
 
    return (
       <LanguageDetailsProvider language={language}>
@@ -106,6 +130,12 @@ export default function LanguageDetailsContent({ language }: LanguageDetailsCont
                            {language.updated_at && <span>{new Date(language.updated_at).toLocaleString()}</span>}
                            {!language.updated_at && <span>--</span>}
                         </DataContainer>
+                     </Card>
+
+                     <Card {...cardProps}>
+                        <Form hideSubmit onSubmit={handleDelete}>
+                           <FormSubmit color="error" fullWidth label="Delete Language" startIcon={<Delete />} />
+                        </Form>
                      </Card>
                   </Fragment>
                </ContentSidebar>

--- a/src/components/content/admin/language/LanguageDetailsContent/LanguageDetailsContent.tsx
+++ b/src/components/content/admin/language/LanguageDetailsContent/LanguageDetailsContent.tsx
@@ -6,12 +6,18 @@ import LanguageDetailsProvider from './LanguageDetailsContext';
 import { useTextResources } from '@/services/TextResources/TextResourcesProvider';
 import texts from './LanguageDetailsContent.texts';
 import { ContentSidebar, DataContainer } from '@/components/layout';
-import { Fragment } from 'react';
+import { Fragment, useState } from 'react';
 import { Card, Container } from '@/components/common';
 import { CardProps } from '@/components/common/Card/Card.types';
+import { EditButtons } from '@/components/buttons';
+import EditLanguageDetailsForm from '@/components/forms/languages/EditLanguageDetailsForm/EditLanguageDetailsForm';
+import EditLevelsForm from '@/components/forms/languages/EditLevelsForm/EditLevelsForm';
 
 export default function LanguageDetailsContent({ language }: LanguageDetailsContentProps) {
+   const [ detailsEdit, setDetailEdit ] = useState<boolean>(false);
+   const [ levelsEdit, setLevelsEdit ] = useState<boolean>(false);
    const { textResources } = useTextResources(texts);
+
    const cardProps: CardProps = { padding: 'm' };
 
    return (
@@ -27,43 +33,61 @@ export default function LanguageDetailsContent({ language }: LanguageDetailsCont
                   <Fragment>
                      <WidgetHeader
                         title={textResources.getText('LanguageDetails.detailsHeader.title')}
-                     />
+                     >
+                        <EditButtons
+                           editMode={detailsEdit}
+                           setEditMode={setDetailEdit}
+                        />
+                     </WidgetHeader>
 
                      <Card {...cardProps}>
-                        <DataContainer>
-                           <label>{textResources.getText('LanguageDetails.field.defaultName')}</label>
-                           <span>{language.default_name}</span>
-                        </DataContainer>
-                        <DataContainer>
-                           <label>{textResources.getText('LanguageDetails.field.localName')}</label>
-                           <span>{language.local_name}</span>
-                        </DataContainer>
-                        <DataContainer>
-                           <label>{textResources.getText('LanguageDetails.field.localeCode')}</label>
-                           <span>{language.locale_code}</span>
-                        </DataContainer>
+                        {detailsEdit && <EditLanguageDetailsForm />}
+                        {!detailsEdit && (
+                           <Fragment>
+                              <DataContainer>
+                                 <label>{textResources.getText('LanguageDetails.field.defaultName')}</label>
+                                 <span>{language.default_name}</span>
+                              </DataContainer>
+                              <DataContainer>
+                                 <label>{textResources.getText('LanguageDetails.field.localName')}</label>
+                                 <span>{language.local_name}</span>
+                              </DataContainer>
+                              <DataContainer>
+                                 <label>{textResources.getText('LanguageDetails.field.localeCode')}</label>
+                                 <span>{language.locale_code}</span>
+                              </DataContainer>
+                           </Fragment>
+                        )}
                      </Card>
 
-                     <WidgetHeader
-                        title={textResources.getText('LanguageDetails.levelsHeader.title')}
-                     />
+                     <WidgetHeader title={textResources.getText('LanguageDetails.levelsHeader.title')}>
+                        <EditButtons
+                           editMode={levelsEdit}
+                           setEditMode={setLevelsEdit}
+                        />
+                     </WidgetHeader>
                      <Card {...cardProps}>
-                        <DataContainer vertical>
-                           <label>{textResources.getText('LanguageDetails.field.readingLevel')}</label>
-                           <span>{language.reading_level}</span>
-                        </DataContainer>
-                        <DataContainer vertical>
-                           <label>{textResources.getText('LanguageDetails.field.writingLevel')}</label>
-                           <span>{language.writing_level}</span>
-                        </DataContainer>
-                        <DataContainer vertical>
-                           <label>{textResources.getText('LanguageDetails.field.speakingLevel')}</label>
-                           <span>{language.speaking_level}</span>
-                        </DataContainer>
-                        <DataContainer vertical>
-                           <label>{textResources.getText('LanguageDetails.field.listeningLevel')}</label>
-                           <span>{language.listening_level}</span>
-                        </DataContainer>
+                        {levelsEdit && <EditLevelsForm />}
+                        {!levelsEdit && (
+                           <Fragment>
+                              <DataContainer vertical>
+                                 <label>{textResources.getText('LanguageDetails.field.readingLevel')}</label>
+                                 <span>{language.reading_level}</span>
+                              </DataContainer>
+                              <DataContainer vertical>
+                                 <label>{textResources.getText('LanguageDetails.field.writingLevel')}</label>
+                                 <span>{language.writing_level}</span>
+                              </DataContainer>
+                              <DataContainer vertical>
+                                 <label>{textResources.getText('LanguageDetails.field.speakingLevel')}</label>
+                                 <span>{language.speaking_level}</span>
+                              </DataContainer>
+                              <DataContainer vertical>
+                                 <label>{textResources.getText('LanguageDetails.field.listeningLevel')}</label>
+                                 <span>{language.listening_level}</span>
+                              </DataContainer>
+                           </Fragment>
+                        )}
                      </Card>
                   </Fragment>
 

--- a/src/components/content/admin/language/LanguageDetailsContent/LanguageDetailsContent.types.ts
+++ b/src/components/content/admin/language/LanguageDetailsContent/LanguageDetailsContent.types.ts
@@ -1,0 +1,10 @@
+import { LanguageData } from '@/types/database.types';
+
+export interface LanguageDetailsContentProps {
+   language: LanguageData;
+}
+
+export interface LanguageDetailsContextProps {
+   language: LanguageData;
+   children: React.ReactNode;
+}

--- a/src/components/content/admin/language/LanguageDetailsContent/LanguageDetailsContext.tsx
+++ b/src/components/content/admin/language/LanguageDetailsContent/LanguageDetailsContext.tsx
@@ -1,0 +1,23 @@
+import { LanguageData } from '@/types/database.types';
+import { createContext, useContext } from 'react';
+import { LanguageDetailsContextProps } from './LanguageDetailsContent.types';
+
+export const LanguageDetailsContext = createContext<LanguageData | null>(null);
+
+export default function LanguageDetailsProvider({ language, children }: LanguageDetailsContextProps): React.ReactElement {
+   return (
+      <LanguageDetailsContext.Provider value={language}>
+         {children}
+      </LanguageDetailsContext.Provider>
+   );
+}
+
+export function useLanguageDetails() {
+   const context = useContext(LanguageDetailsContext);
+
+   if (context === null) {
+      throw new Error('useLanguageDetails must be used within an LanguageDetailsProvider');
+   }
+
+   return context;
+}

--- a/src/components/content/admin/language/index.tsx
+++ b/src/components/content/admin/language/index.tsx
@@ -1,0 +1,1 @@
+export { default as LanguageCreateContent } from './LanguageCreateContent/LanguageCreateContent';

--- a/src/components/forms/languages/CreateLanguageForm/CreateLanguageForm.texts.ts
+++ b/src/components/forms/languages/CreateLanguageForm/CreateLanguageForm.texts.ts
@@ -1,0 +1,35 @@
+import { TextResources } from '@/services';
+
+const textResources = new TextResources();
+
+textResources.create('CreateLanguageForm.default_name.label', 'Default Name');
+textResources.create('CreateLanguageForm.default_name.label', 'Nome Padrão', 'pt');
+textResources.create('CreateLanguageForm.default_name.placeholder', 'Enter the default name. (Eg.: Portuguese)');
+textResources.create('CreateLanguageForm.default_name.placeholder', 'Insira o nome padrão. (Ex.: Portuguese)', 'pt');
+
+textResources.create('CreateLanguageForm.local_name.label', 'Local Name');
+textResources.create('CreateLanguageForm.local_name.label', 'Nome Local', 'pt');
+textResources.create('CreateLanguageForm.local_name.placeholder', 'Enter the local name. (Eg.: Português)');
+textResources.create('CreateLanguageForm.local_name.placeholder', 'Insira o nome local. (Ex.: Português)', 'pt');
+
+textResources.create('CreateLanguageForm.locale_code.label', 'Locale Code');
+textResources.create('CreateLanguageForm.locale_code.label', 'Código Local', 'pt');
+textResources.create('CreateLanguageForm.locale_code.placeholder', 'Enter the locale code. (Eg.: "en")');
+textResources.create('CreateLanguageForm.locale_code.placeholder', 'Insira o código local. (Ex.: "pt")', 'pt');
+
+textResources.create('CreateLanguageForm.reading_level.label', 'Reading Level');
+textResources.create('CreateLanguageForm.reading_level.label', 'Nível de Leitura', 'pt');
+
+textResources.create('CreateLanguageForm.writing_level.label', 'Writing Level');
+textResources.create('CreateLanguageForm.writing_level.label', 'Nível de Escrita', 'pt');
+
+textResources.create('CreateLanguageForm.speaking_level.label', 'Speaking Level');
+textResources.create('CreateLanguageForm.speaking_level.label', 'Nível de Fala', 'pt');
+
+textResources.create('CreateLanguageForm.listening_level.label', 'Listening Level');
+textResources.create('CreateLanguageForm.listening_level.label', 'Nível de Audição', 'pt');
+
+textResources.create('CreateLanguageForm.submit.label', 'Create Language');
+textResources.create('CreateLanguageForm.submit.label', 'Criar Idioma', 'pt');
+
+export default textResources;

--- a/src/components/forms/languages/CreateLanguageForm/CreateLanguageForm.tsx
+++ b/src/components/forms/languages/CreateLanguageForm/CreateLanguageForm.tsx
@@ -1,0 +1,95 @@
+import { Form, FormInput, FormSelect, FormSubmit } from '@/hooks';
+import { useTextResources } from '@/services/TextResources/TextResourcesProvider';
+import texts from './CreateLanguageForm.texts'
+import { ContentSidebar } from '@/components/layout';
+import { Fragment } from 'react';
+import { Card, Container } from '@/components/common';
+import { CardProps } from '@/components/common/Card/Card.types';
+import { languageLevels } from '@/app.config';
+import { FormValues } from '@/hooks/Form/Form.types';
+import { useAjax } from '@/hooks/useAjax';
+import { LanguageData } from '@/types/database.types';
+import { useRouter } from 'next/navigation';
+
+export default function CreateLanguageForm() {
+   const { textResources } = useTextResources(texts);
+   const ajax = useAjax();
+   const router = useRouter();
+
+   const cardProps: CardProps = { padding: 'm' };
+
+   const handleSubmit = async (values: FormValues) => {
+      try {
+         const created = await ajax.post<LanguageData>('/language/create', values);
+
+         if (!created.success) {
+            throw created;
+         }
+
+         if (created.data?.id) {
+            router.push(`/admin/language/${created.data.id}`);
+         }
+
+         return created;
+      } catch (error) {
+         return error;
+      }
+   };
+
+   return (
+      <Container>
+         <Form hideSubmit onSubmit={handleSubmit}>
+            <ContentSidebar>
+               <Fragment>
+                  <Card {...cardProps}>
+                     <FormInput
+                        fieldName="default_name"
+                        label={textResources.getText('CreateLanguageForm.default_name.label')}
+                        placeholder={textResources.getText('CreateLanguageForm.default_name.placeholder')}
+                     />
+                     <FormInput
+                        fieldName="local_name"
+                        label={textResources.getText('CreateLanguageForm.local_name.label')}
+                        placeholder={textResources.getText('CreateLanguageForm.local_name.placeholder')}
+                     />
+                     <FormInput
+                        fieldName="locale_code"
+                        label={textResources.getText('CreateLanguageForm.locale_code.label')}
+                        placeholder={textResources.getText('CreateLanguageForm.locale_code.placeholder')}
+                        max={2}
+                     />
+                  </Card>
+               </Fragment>
+
+               <Fragment>
+                  <Card {...cardProps}>
+                     <FormSelect
+                        fieldName="reading_level"
+                        label={textResources.getText('CreateLanguageForm.reading_level.label')}
+                        options={languageLevels}
+                     />
+                     <FormSelect
+                        fieldName="writing_level"
+                        label={textResources.getText('CreateLanguageForm.writing_level.label')}
+                        options={languageLevels}
+                     />
+                     <FormSelect
+                        fieldName="speaking_level"
+                        label={textResources.getText('CreateLanguageForm.speaking_level.label')}
+                        options={languageLevels}
+                     />
+                     <FormSelect
+                        fieldName="listening_level"
+                        label={textResources.getText('CreateLanguageForm.listening_level.label')}
+                        options={languageLevels}
+                     />
+                  </Card>
+                  <Card {...cardProps}>
+                     <FormSubmit label={textResources.getText('CreateLanguageForm.submit.label')} fullWidth />
+                  </Card>
+               </Fragment>
+            </ContentSidebar>
+         </Form>
+      </Container>
+   );
+}

--- a/src/components/forms/languages/EditLanguageDetailsForm/EditLanguageDetailsForm.texts.ts
+++ b/src/components/forms/languages/EditLanguageDetailsForm/EditLanguageDetailsForm.texts.ts
@@ -1,0 +1,14 @@
+import { TextResources } from '@/services';
+
+const textResources = new TextResources();
+
+textResources.create('EditLanguageDetailsForm.default_name', 'Default Name');
+textResources.create('EditLanguageDetailsForm.default_name', 'Nome Padrão', 'pt');
+
+textResources.create('EditLanguageDetailsForm.local_name', 'Local Name');
+textResources.create('EditLanguageDetailsForm.local_name', 'Nome Local', 'pt');
+
+textResources.create('EditLanguageDetailsForm.locale_code', 'Locale Code');
+textResources.create('EditLanguageDetailsForm.locale_code', 'Código Local', 'pt');
+
+export default textResources;

--- a/src/components/forms/languages/EditLanguageDetailsForm/EditLanguageDetailsForm.tsx
+++ b/src/components/forms/languages/EditLanguageDetailsForm/EditLanguageDetailsForm.tsx
@@ -1,0 +1,36 @@
+import { useLanguageDetails } from '@/components/content/admin/language/LanguageDetailsContent/LanguageDetailsContext';
+import { Form, FormInput } from '@/hooks';
+import { FormValues } from '@/hooks/Form/Form.types';
+import { useAjax } from '@/hooks/useAjax';
+import { useTextResources } from '@/services/TextResources/TextResourcesProvider';
+import { LanguageData } from '@/types/database.types';
+import texts from './EditLanguageDetailsForm.texts';
+
+export default function EditLanguageDetailsForm() {
+   const { textResources } = useTextResources(texts);
+   const language = useLanguageDetails();
+   const ajax = useAjax();
+
+   const handleUpdate = async (values: FormValues) => {
+      try {
+         const updated = await ajax.patch<LanguageData>('/language/update', values);
+
+         if (!updated.success) {
+            throw updated;
+         }
+
+         window.location.reload();
+         return updated.data;
+      } catch (error) {
+         return error;
+      }
+   };
+
+   return (
+      <Form initialValues={{...language}} editMode onSubmit={handleUpdate}>
+         <FormInput fieldName="default_name" label={textResources.getText('EditLanguageDetailsForm.default_name')} />
+         <FormInput fieldName="local_name" label={textResources.getText('EditLanguageDetailsForm.local_name')} />
+         <FormInput fieldName="locale_code" label={textResources.getText('EditLanguageDetailsForm.locale_code')} />
+      </Form>
+   );
+}

--- a/src/components/forms/languages/EditLanguageDetailsForm/EditLanguageDetailsForm.tsx
+++ b/src/components/forms/languages/EditLanguageDetailsForm/EditLanguageDetailsForm.tsx
@@ -13,7 +13,7 @@ export default function EditLanguageDetailsForm() {
 
    const handleUpdate = async (values: FormValues) => {
       try {
-         const updated = await ajax.patch<LanguageData>('/language/update', values);
+         const updated = await ajax.patch<LanguageData>('/language/update', { language_id: language.id, updates: values });
 
          if (!updated.success) {
             throw updated;

--- a/src/components/forms/languages/EditLevelsForm/EditLevelsForm.texts.ts
+++ b/src/components/forms/languages/EditLevelsForm/EditLevelsForm.texts.ts
@@ -1,0 +1,17 @@
+import { TextResources } from '@/services';
+
+const textResources = new TextResources();
+
+textResources.create('EditLevelsForm.reading_level', 'Reading');
+textResources.create('EditLevelsForm.reading_level', 'Leitura', 'pt');
+
+textResources.create('EditLevelsForm.writing_level', 'Writing');
+textResources.create('EditLevelsForm.writing_level', 'Escrita', 'pt');
+
+textResources.create('EditLevelsForm.speaking_level', 'Speaking');
+textResources.create('EditLevelsForm.speaking_level', 'Fala', 'pt');
+
+textResources.create('EditLevelsForm.listening_level', 'Listening');
+textResources.create('EditLevelsForm.listening_level', 'Audição', 'pt');
+
+export default textResources;

--- a/src/components/forms/languages/EditLevelsForm/EditLevelsForm.tsx
+++ b/src/components/forms/languages/EditLevelsForm/EditLevelsForm.tsx
@@ -1,0 +1,53 @@
+import { useLanguageDetails } from '@/components/content/admin/language/LanguageDetailsContent/LanguageDetailsContext';
+import { Form, FormSelect } from '@/hooks';
+import { useTextResources } from '@/services/TextResources/TextResourcesProvider';
+import texts from './EditLevelsForm.texts';
+import { languageLevels } from '@/app.config';
+import { FormValues } from '@/hooks/Form/Form.types';
+import { useAjax } from '@/hooks/useAjax';
+import { LanguageData } from '@/types/database.types';
+
+export default function EditLevelsForm() {
+   const language = useLanguageDetails();
+   const { textResources } = useTextResources(texts);
+   const ajax = useAjax();
+
+   const handleUpdate = async (values: FormValues) => {
+      try {
+         const updated = await ajax.patch<LanguageData>('/language/update', { language_id: language.id, updates: values });
+         if (!updated.success) {
+            throw updated;
+         }
+
+         window.location.reload();
+         return updated;
+      } catch (error) {
+         return error;
+      }
+   }
+
+   return (
+      <Form initialValues={{...language}} onSubmit={handleUpdate} editMode>
+         <FormSelect
+            fieldName="reading_level"
+            label={textResources.getText('EditLevelsForm.reading_level')}
+            options={languageLevels}
+         />
+         <FormSelect
+            fieldName="writing_level"
+            label={textResources.getText('EditLevelsForm.writing_level')}
+            options={languageLevels}
+         />
+         <FormSelect
+            fieldName="speaking_level"
+            label={textResources.getText('EditLevelsForm.speaking_level')}
+            options={languageLevels}
+         />
+         <FormSelect
+            fieldName="listening_level"
+            label={textResources.getText('EditLevelsForm.listening_level')}
+            options={languageLevels}
+         />
+      </Form>
+   );
+}

--- a/src/components/forms/languages/index.tsx
+++ b/src/components/forms/languages/index.tsx
@@ -1,0 +1,1 @@
+export { default as CreateLanguageForm } from './CreateLanguageForm/CreateLanguageForm';

--- a/src/components/widgets/LanguagesWidget/LanguagesWidget.texts.ts
+++ b/src/components/widgets/LanguagesWidget/LanguagesWidget.texts.ts
@@ -1,0 +1,11 @@
+import { TextResources } from "@/services";
+
+const textResources = new TextResources();
+
+textResources.create('LanguagesWidget.title', 'Languages');
+textResources.create('LanguagesWidget.title', 'Linguagens', 'pt');
+
+textResources.create('LanguagesWidget.addButton.title', 'Add Language');
+textResources.create('LanguagesWidget.addButton.title', 'Adicionar Idioma', 'pt');
+
+export default textResources;

--- a/src/components/widgets/LanguagesWidget/LanguagesWidget.texts.ts
+++ b/src/components/widgets/LanguagesWidget/LanguagesWidget.texts.ts
@@ -8,4 +8,19 @@ textResources.create('LanguagesWidget.title', 'Linguagens', 'pt');
 textResources.create('LanguagesWidget.addButton.title', 'Add Language');
 textResources.create('LanguagesWidget.addButton.title', 'Adicionar Idioma', 'pt');
 
+textResources.create('LanguagesWidget.noLanguages', 'No languages found');
+textResources.create('LanguagesWidget.noLanguages', 'Nenhuma linguagem encontrada', 'pt');
+
+textResources.create('LanguagesWidget.levels.reading', (level) => `Reading: ${level}`);
+textResources.create('LanguagesWidget.levels.reading', (level) => `Leitura: ${level}`, 'pt');
+
+textResources.create('LanguagesWidget.levels.writing', (level) => `Writing: ${level}`);
+textResources.create('LanguagesWidget.levels.writing', (level) => `Escrita: ${level}`, 'pt');
+
+textResources.create('LanguagesWidget.levels.speaking', (level) => `Speaking: ${level}`);
+textResources.create('LanguagesWidget.levels.speaking', (level) => `Fala: ${level}`, 'pt');
+
+textResources.create('LanguagesWidget.levels.listening', (level) => `Listening: ${level}`);
+textResources.create('LanguagesWidget.levels.listening', (level) => `Audição: ${level}`, 'pt');
+
 export default textResources;

--- a/src/components/widgets/LanguagesWidget/LanguagesWidget.tsx
+++ b/src/components/widgets/LanguagesWidget/LanguagesWidget.tsx
@@ -37,7 +37,7 @@ export default function LanguagesWidget({ className, languages = [] }: LanguageW
       }).finally(() => {
          setLoading(false);
       });
-   }, []);
+   }, [ ajax ]);
 
    return (
       <div className={CSS}>

--- a/src/components/widgets/LanguagesWidget/LanguagesWidget.tsx
+++ b/src/components/widgets/LanguagesWidget/LanguagesWidget.tsx
@@ -56,6 +56,7 @@ export default function LanguagesWidget({ className, languages = [] }: LanguageW
             hideHeader
             items={langs}
             loading={loading}
+            noDocumentsText={textResources.getText('LanguagesWidget.noLanguages')}
             onClickRow={(item) => router.push(`/admin/language/${item.id}`)}
             columnConfig={[
                {
@@ -69,10 +70,10 @@ export default function LanguagesWidget({ className, languages = [] }: LanguageW
                      const row = item as LanguageData;
 
                      return <ul>
-                        <li>Reading: {row.reading_level}</li>
-                        <li>Writing: {row.writing_level}</li>
-                        <li>Speaking: {row.speaking_level}</li>
-                        <li>Listening: {row.listening_level}</li>
+                        <li>{textResources.getText('LanguagesWidget.levels.reading', row.reading_level)}</li>
+                        <li>{textResources.getText('LanguagesWidget.levels.writing', row.writing_level)}</li>
+                        <li>{textResources.getText('LanguagesWidget.levels.speaking', row.speaking_level)}</li>
+                        <li>{textResources.getText('LanguagesWidget.levels.listening', row.listening_level)}</li>
                      </ul>;
                   }
                }

--- a/src/components/widgets/LanguagesWidget/LanguagesWidget.tsx
+++ b/src/components/widgets/LanguagesWidget/LanguagesWidget.tsx
@@ -1,0 +1,83 @@
+import { WidgetHeader } from '@/components/headers';
+import { useTextResources } from '@/services/TextResources/TextResourcesProvider';
+import texts from './LanguagesWidget.texts'
+import { TableBase } from '@/components/common';
+import { LanguageWidgetProps } from './LanguagesWidget.types';
+import React, { useEffect, useRef, useState } from 'react';
+import { parseCSS } from '@/helpers/parse.helpers';
+import { useAjax } from '@/hooks/useAjax';
+import { LanguageData } from '@/types/database.types';
+import { useRouter } from 'next/navigation';
+import { RoundButton } from '@/components/buttons';
+import Link from 'next/link';
+import { Add } from '@mui/icons-material';
+
+export default function LanguagesWidget({ className, languages = [] }: LanguageWidgetProps) {
+   const [ loading, setLoading ] = useState<boolean>(true);
+   const [ langs, setLangs ] = useState<LanguageData[]>(languages);
+   const isReady = useRef<boolean>(false);
+   const { textResources } = useTextResources(texts);
+   const ajax = useAjax();
+   const router = useRouter();
+
+   const CSS = parseCSS(className, [
+      'LanguagesWidget'
+   ]);
+
+   useEffect(() => {
+      if (isReady.current) {
+         return;
+      }
+
+      isReady.current = true;
+      ajax.get<LanguageData[]>('/user/languages').then((response) => {
+         setLangs(response.data as LanguageData[]);
+      }).catch(err => {
+         console.error('Error fetching languages:', err);
+      }).finally(() => {
+         setLoading(false);
+      });
+   }, []);
+
+   return (
+      <div className={CSS}>
+         <WidgetHeader title={textResources.getText('LanguagesWidget.title')}>
+            <RoundButton
+               title={textResources.getText('LanguagesWidget.addButton.title')}
+               LinkComponent={Link}
+               color="primary"
+               href="/admin/language/create"
+            >
+               <Add />
+            </RoundButton>
+         </WidgetHeader>
+
+         <TableBase
+            hideHeader
+            items={langs}
+            loading={loading}
+            onClickRow={(item) => router.push(`/admin/language/${item.id}`)}
+            columnConfig={[
+               {
+                  propKey: 'local_name',
+                  label: '--'
+               },
+               {
+                  propKey: 'levels',
+                  label: '--',
+                  format: (_, item) => {
+                     const row = item as LanguageData;
+
+                     return <ul>
+                        <li>Reading: {row.reading_level}</li>
+                        <li>Writing: {row.writing_level}</li>
+                        <li>Speaking: {row.speaking_level}</li>
+                        <li>Listening: {row.listening_level}</li>
+                     </ul>;
+                  }
+               }
+            ]}
+         />
+      </div>
+   );
+}

--- a/src/components/widgets/LanguagesWidget/LanguagesWidget.types.ts
+++ b/src/components/widgets/LanguagesWidget/LanguagesWidget.types.ts
@@ -1,0 +1,6 @@
+import { LanguageData } from "@/types/database.types";
+
+export interface LanguageWidgetProps {
+   className?: string | string[];
+   languages?: LanguageData[];
+}

--- a/src/components/widgets/index.tsx
+++ b/src/components/widgets/index.tsx
@@ -2,3 +2,4 @@ export { default as ExperiencesWidget } from './ExperiencesWidget/ExperiencesWid
 export { default as CompaniesWidget } from './CompaniesWidget/CompaniesWidget';
 export { default as SkillsWidget } from './SkillsWidget/SkillsWidget';
 export { default as CVsWidget } from './CVsWidget/CVsWidget';
+export { default as LanguagesWidget } from './LanguagesWidget/LanguagesWidget';

--- a/src/services/Ajax/Ajax.ts
+++ b/src/services/Ajax/Ajax.ts
@@ -69,7 +69,8 @@ export default class Ajax {
                status: response.status,
                statusText: response.statusText,
                headers: response.headers,
-               success: true
+               success: true,
+               error: false
             };
          } catch (error) {
             if (attempt === retries) {

--- a/src/services/Ajax/Ajax.types.ts
+++ b/src/services/Ajax/Ajax.types.ts
@@ -19,6 +19,7 @@ export interface AjaxResponse<T = unknown> {
    statusText: string;
    headers: Record<string, unknown>;
    success: boolean;
+   error: false;
    message?: string;
 }
 

--- a/src/services/Ajax/Ajax.types.ts
+++ b/src/services/Ajax/Ajax.types.ts
@@ -18,7 +18,7 @@ export interface AjaxResponse<T = unknown> {
    code?: string;
    statusText: string;
    headers: Record<string, unknown>;
-   success: boolean;
+   success: true;
    error: false;
    message?: string;
 }

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -81,3 +81,13 @@ export interface CVSetData extends BasicData {
    cv_id: number;
    user?: UserData;
 }
+
+export interface LanguageData extends BasicData {
+   default_name: string;
+   local_name: string;
+   locale_code: string;
+   reading_level: string;
+   writing_level: string;
+   speaking_level: string;
+   listening_level: string;
+}


### PR DESCRIPTION
## [FRD-140] Description
This pull request introduces a comprehensive admin interface for managing languages, including the ability to create new language entries, view and edit language details, and manage language proficiency levels. It also adds internationalization support for these features and integrates language management into the admin dashboard.

**Admin Language Management Features:**

- Added a new admin page for creating languages, including the `LanguageCreateContent` component and form, with support for internationalized labels and placeholders. [[1]](diffhunk://#diff-307f661d937d3dfc31073ea830a1b7ce5dc2658cdc9c92aba5f74fdc55ad048eR1-R13) [[2]](diffhunk://#diff-ae135780148f5fa43299f888bd82683182109910cc46643a46ba5bc19dc7bfb7R1-R14) [[3]](diffhunk://#diff-bb925cde86f01e05ff62373c941eb28e479b60ae096db9f5137246234e59065aR1) [[4]](diffhunk://#diff-3e1ef6f3469812b6eadb784cf81519398b7bef9d379589b06fcb0c0d79f69be3R1-R95) [[5]](diffhunk://#diff-a9960262d58b122b3319062f0a77d772b859af639bb3e7ec83171340029ce052R1-R35)
- Implemented a detailed language view page, allowing admins to view, edit, and delete languages, as well as manage proficiency levels, with full internationalization support. ([src/app/admin/language/[language_id]/page.tsxR1-R29](diffhunk://#diff-7b03ac4c98ae90a35c5d00f9f80ce97c3dfc20b1f9fe90bd1cbf8881ff39c82fR1-R29), [[1]](diffhunk://#diff-7cfba55ac2cf03d76c0e1c882f4bf14c5235ffbaea58a12c21a43095a1b2152fR1-R146) [[2]](diffhunk://#diff-574da79d4c3fbbd38fec74f796100d703710408363d6438781d285ed1afc0eddR1-R50) [[3]](diffhunk://#diff-0122a2df8488c251334aba6f269a9f866dc7d7e2a6fb92818927c9d3f260bf04R1-R10) [[4]](diffhunk://#diff-71b6949733485b495da0fa8c70a62552ddb2152b78d754c6b196a991b77f9f34R1-R23)

**Internationalization and Config Improvements:**

- Added English and Portuguese text resources for all new language management forms and components. [[1]](diffhunk://#diff-a9960262d58b122b3319062f0a77d772b859af639bb3e7ec83171340029ce052R1-R35) [[2]](diffhunk://#diff-bab2d9de8056cfa8bac6e06f34459c8409e9ab06538e9eafac373298fb363639R1-R14) [[3]](diffhunk://#diff-574da79d4c3fbbd38fec74f796100d703710408363d6438781d285ed1afc0eddR1-R50)
- Introduced a `languageLevels` configuration array for standardized language proficiency options.

**Dashboard Integration:**

- Added a `LanguagesWidget` to the admin dashboard sidebar to provide quick access to language management features.

These changes collectively provide a robust foundation for language management in the admin panel, with extensible and localized UI components.

### Sub-tasks
* [FRD-141] Create Language - Page (#129)
Introduces a new admin page for creating language entries, including a form component with fields for default name, local name, locale code, and language proficiency levels. Adds supporting text resources for form labels and placeholders, updates app config with language levels, and defines the LanguageData type.

* [FRD-142] Languages Widget (#130)
Introduced a new LanguagesWidget component with supporting types and text resources. Updated the admin dashboard sidebar to include the LanguagesWidget. Refactored imports for LanguageCreateContent and CreateLanguageForm to use new index files for cleaner imports.

* [FRD-143] Language Details - Read (#131)
Introduces a new admin page for viewing language details, including a LanguageDetailsContent component, context provider, and localized text resources. Also updates AjaxResponse type to include an 'error' property.

* [FRD-144] Language Details - Edit (#132)
Introduced EditLanguageDetailsForm and EditLevelsForm components, allowing inline editing of language details and proficiency levels in LanguageDetailsContent. Added corresponding text resources for form labels and integrated edit mode toggling with EditButtons.

* [FRD-145] Language Delete (#133)
Introduced a delete button in the language details admin page, including a confirmation prompt and backend call to remove the language. Added corresponding text resources for the confirmation dialog in English and Portuguese.

[FRD-140]: https://feliperamosdev.atlassian.net/browse/FRD-140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[FRD-141]: https://feliperamosdev.atlassian.net/browse/FRD-141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ