### PR TITLE
[FRD-148] Educations Widget

### DIFF
--- a/src/components/content/admin/DashboardContent/sections/DashboardArticle/DashboardArticle.tsx
+++ b/src/components/content/admin/DashboardContent/sections/DashboardArticle/DashboardArticle.tsx
@@ -1,8 +1,9 @@
-import { CVsWidget, ExperiencesWidget } from '@/components/widgets';
+import { CVsWidget, ExperiencesWidget, EducationsWidget } from '@/components/widgets';
 
 export default function DashboardArticle(): React.ReactElement {
    return (<>
       <CVsWidget />
       <ExperiencesWidget />
+      <EducationsWidget />
    </>);
 }

--- a/src/components/widgets/EducationsWidget/EducationsWidget.texts.ts
+++ b/src/components/widgets/EducationsWidget/EducationsWidget.texts.ts
@@ -1,0 +1,14 @@
+import { TextResources } from '@/services';
+
+const textResources = new TextResources();
+
+textResources.create('EducationsWidget.headerTitle', 'Educations');
+textResources.create('EducationsWidget.headerTitle', 'Educações', 'pt');
+
+textResources.create('EducationsWidget.addButton', 'Add Education');
+textResources.create('EducationsWidget.addButton', 'Adicionar Educação', 'pt');
+
+textResources.create('EducationsWidget.noData', 'No education data available.');
+textResources.create('EducationsWidget.noData', 'Nenhum dado educacional disponível.', 'pt');
+
+export default textResources;

--- a/src/components/widgets/EducationsWidget/EducationsWidget.tsx
+++ b/src/components/widgets/EducationsWidget/EducationsWidget.tsx
@@ -14,8 +14,8 @@ import type {
    EducationsWidgetProps
 } from './EducationsWidget.types';
 
-export default function EducationsWidget({ educations = [] }: EducationsWidgetProps) {
-   const [ edus, setEdus ] = useState<EducationData[]>(educations);
+export default function EducationsWidget({ educations }: EducationsWidgetProps) {
+   const [ edus, setEdus ] = useState<EducationData[]>(educations || []);
    const [ loading, setLoading ] = useState<boolean>(false);
    const { textResources } = useTextResources(texts);
    const isLoaded = useRef<boolean>(false);
@@ -23,7 +23,7 @@ export default function EducationsWidget({ educations = [] }: EducationsWidgetPr
    const router = useRouter();
 
    useEffect(() => {
-      if (isLoaded.current) return;
+      if (isLoaded.current || educations) return;
 
       isLoaded.current = true;
       ajax.get<EducationData[]>('/user/educations').then((response) => {
@@ -37,7 +37,7 @@ export default function EducationsWidget({ educations = [] }: EducationsWidgetPr
       }).finally(() => {
          setLoading(false);
       });
-   }, []);
+   }, [ ajax, educations ]);
 
    return (
       <div className="EducationsWidget">
@@ -47,7 +47,9 @@ export default function EducationsWidget({ educations = [] }: EducationsWidgetPr
                LinkComponent={Link}
                href="/admin/education/create"
                color="primary"
-            ><Add /></RoundButton>
+            >
+               <Add />
+            </RoundButton>
          </WidgetHeader>
 
          <TableBase
@@ -55,6 +57,7 @@ export default function EducationsWidget({ educations = [] }: EducationsWidgetPr
             items={edus}
             loading={loading}
             onClickRow={(item) => router.push(`/admin/education/${item.id}`)}
+            noDocumentsText={textResources.getText('EducationsWidget.noData')}
             columnConfig={[{
                propKey: 'data',
                label: '---',
@@ -64,7 +67,7 @@ export default function EducationsWidget({ educations = [] }: EducationsWidgetPr
 
                   return <>
                      <b>{item.institution_name}</b><br />
-                     <span>{item.field_of_study}</span>
+                     <span>{item.field_of_study ?? '---'}</span>
                      <p><DateView date={item.start_date} /> to <DateView date={item.end_date} /></p>
                   </>;
                }

--- a/src/components/widgets/EducationsWidget/EducationsWidget.tsx
+++ b/src/components/widgets/EducationsWidget/EducationsWidget.tsx
@@ -1,0 +1,75 @@
+import { WidgetHeader } from '@/components/headers';
+import { useTextResources } from '@/services/TextResources/TextResourcesProvider';
+import texts from './EducationsWidget.texts';
+import { RoundButton } from '@/components/buttons';
+import { Add } from '@mui/icons-material';
+import Link from 'next/link';
+import { useEffect, useRef, useState } from 'react';
+import { EducationData } from '@/types/database.types';
+import { useAjax } from '@/hooks/useAjax';
+import { DateView, TableBase } from '@/components/common';
+import { useRouter } from 'next/navigation';
+
+import type {
+   EducationsWidgetProps
+} from './EducationsWidget.types';
+
+export default function EducationsWidget({ educations = [] }: EducationsWidgetProps) {
+   const [ edus, setEdus ] = useState<EducationData[]>(educations);
+   const [ loading, setLoading ] = useState<boolean>(false);
+   const { textResources } = useTextResources(texts);
+   const isLoaded = useRef<boolean>(false);
+   const ajax = useAjax();
+   const router = useRouter();
+
+   useEffect(() => {
+      if (isLoaded.current) return;
+
+      isLoaded.current = true;
+      ajax.get<EducationData[]>('/user/educations').then((response) => {
+         if (response.error) {
+            throw new Error(response.message);
+         }
+
+         setEdus(response.data);
+      }).catch((err) => {
+         console.error(err);
+      }).finally(() => {
+         setLoading(false);
+      });
+   }, []);
+
+   return (
+      <div className="EducationsWidget">
+         <WidgetHeader title={textResources.getText('EducationsWidget.headerTitle')}>
+            <RoundButton
+               title={textResources.getText('EducationsWidget.addButton')}
+               LinkComponent={Link}
+               href="/admin/education/create"
+               color="primary"
+            ><Add /></RoundButton>
+         </WidgetHeader>
+
+         <TableBase
+            hideHeader
+            items={edus}
+            loading={loading}
+            onClickRow={(item) => router.push(`/admin/education/${item.id}`)}
+            columnConfig={[{
+               propKey: 'data',
+               label: '---',
+               format: (_, row) => {
+                  const item = row as EducationData;
+                  
+
+                  return <>
+                     <b>{item.institution_name}</b><br />
+                     <span>{item.field_of_study}</span>
+                     <p><DateView date={item.start_date} /> to <DateView date={item.end_date} /></p>
+                  </>;
+               }
+            }]}
+         />
+      </div>
+   );
+}

--- a/src/components/widgets/EducationsWidget/EducationsWidget.types.ts
+++ b/src/components/widgets/EducationsWidget/EducationsWidget.types.ts
@@ -1,0 +1,5 @@
+import { EducationData } from "@/types/database.types";
+
+export interface EducationsWidgetProps {
+   educations?: EducationData[];
+}

--- a/src/components/widgets/index.tsx
+++ b/src/components/widgets/index.tsx
@@ -3,3 +3,4 @@ export { default as CompaniesWidget } from './CompaniesWidget/CompaniesWidget';
 export { default as SkillsWidget } from './SkillsWidget/SkillsWidget';
 export { default as CVsWidget } from './CVsWidget/CVsWidget';
 export { default as LanguagesWidget } from './LanguagesWidget/LanguagesWidget';
+export { default as EducationsWidget } from './EducationsWidget/EducationsWidget';

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -91,3 +91,21 @@ export interface LanguageData extends BasicData {
    speaking_level: string;
    listening_level: string;
 }
+
+export interface EducationData extends EducationSetData {
+   institution_name: string;
+   start_date: Date;
+   end_date: Date;
+   is_current: boolean;
+   student_id: number;
+}
+
+export interface EducationSetData extends BasicData {
+   degree?: string;
+   field_of_study?: string;
+   grade?: string;
+   description?: string;
+   education_id: number;
+   language_set: string;
+   user_id: number;
+}


### PR DESCRIPTION
## [FRD-148] Description
This pull request introduces a new `EducationsWidget` component to the admin dashboard, allowing users to view and manage their education data. The changes include implementing the widget, defining its types and text resources, updating the dashboard to display it, and extending the database types to support education data.

**New Educations Widget Integration:**

* Added the `EducationsWidget` component, which fetches and displays a list of education records, with support for navigation to create or edit entries. (`src/components/widgets/EducationsWidget/EducationsWidget.tsx`, [src/components/widgets/EducationsWidget/EducationsWidget.tsxR1-R75](diffhunk://#diff-f0aa42c09eb9b3ee042936706a7ce917b7d3635ee45507992516402dff6e14f6R1-R75))
* Integrated the `EducationsWidget` into the admin dashboard by updating the `DashboardArticle` component and the widgets export. (`src/components/content/admin/DashboardContent/sections/DashboardArticle/DashboardArticle.tsx`, [[1]](diffhunk://#diff-5d431c71ff8468492f2d05bc39af998268712589f3a7508a27240f0d12aab248L1-R7); `src/components/widgets/index.tsx`, [[2]](diffhunk://#diff-b6cf1a88169f705f6cebad9478a265c86451f669e93c435e7b2a068d80df9887R6)

**Supporting Infrastructure:**

* Defined the `EducationsWidgetProps` interface to specify the expected props for the new widget. (`src/components/widgets/EducationsWidget/EducationsWidget.types.ts`, [src/components/widgets/EducationsWidget/EducationsWidget.types.tsR1-R5](diffhunk://#diff-738c8904df1e06f2880ec6584f0fd7e7aea3db47ae6b5a648055841ebda6ed45R1-R5))
* Added localized text resources for the widget, supporting both English and Portuguese. (`src/components/widgets/EducationsWidget/EducationsWidget.texts.ts`, [src/components/widgets/EducationsWidget/EducationsWidget.texts.tsR1-R14](diffhunk://#diff-8a0b951e304380183ae15b72ecbb64f073dcb67e48b7ffc979d35358811e8a03R1-R14))

**Database Type Extensions:**

* Extended the database types to include `EducationData` and `EducationSetData`, supporting the structure required by the new widget. (`src/types/database.types.ts`, [src/types/database.types.tsR94-R111](diffhunk://#diff-5b215ddbe1da343b227002e728f9ac8e6d4e3f3579f095d7872deff8061a92b9R94-R111))

[FRD-148]: https://feliperamosdev.atlassian.net/browse/FRD-148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ