### PR TITLE
[FRD-147] Create Education - Page

### DIFF
--- a/src/app/admin/education/create/page.tsx
+++ b/src/app/admin/education/create/page.tsx
@@ -1,0 +1,13 @@
+import { EducationCreateContent } from '@/components/content/admin/education';
+import { AdminPageBase } from '@/components/layout';
+import { headersAcceptLanguage } from '@/helpers';
+
+export default async function EducationCreatePage() {
+   const language = await headersAcceptLanguage();
+
+   return (
+      <AdminPageBase language={language}>
+         <EducationCreateContent />
+      </AdminPageBase>
+   );
+}

--- a/src/components/content/admin/education/EducationCreateContent/EducationCreateContent.texts.ts
+++ b/src/components/content/admin/education/EducationCreateContent/EducationCreateContent.texts.ts
@@ -1,0 +1,11 @@
+import { TextResources } from '@/services';
+
+const textResources = new TextResources();
+
+textResources.create('EducationCreateContent.pageTitle', 'Create Education');
+textResources.create('EducationCreateContent.pageTitle', 'Criar Educação', 'pt');
+
+textResources.create('EducationCreateContent.pageDescription', 'Create a new education record');
+textResources.create('EducationCreateContent.pageDescription', 'Criar um novo registro de educação', 'pt');
+
+export default textResources;

--- a/src/components/content/admin/education/EducationCreateContent/EducationCreateContent.tsx
+++ b/src/components/content/admin/education/EducationCreateContent/EducationCreateContent.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { PageHeader } from '@/components/headers';
+import { useTextResources } from '@/services/TextResources/TextResourcesProvider';
+import texts from './EducationCreateContent.texts';
+import { CreateEducationForm } from '@/components/forms/educations';
+
+export default function EducationCreateContent() {
+   const { textResources } = useTextResources(texts);
+
+   return (
+      <div className="EducationCreateContent">
+         <PageHeader
+            title={textResources.getText('EducationCreateContent.pageTitle')}
+            description={textResources.getText('EducationCreateContent.pageDescription')}
+         />
+
+         <CreateEducationForm />
+      </div>
+   );
+}

--- a/src/components/content/admin/education/index.tsx
+++ b/src/components/content/admin/education/index.tsx
@@ -1,0 +1,1 @@
+export { default as EducationCreateContent } from './EducationCreateContent/EducationCreateContent';

--- a/src/components/forms/educations/CreateEducationForm/CreateEducationForm.texts.ts
+++ b/src/components/forms/educations/CreateEducationForm/CreateEducationForm.texts.ts
@@ -1,0 +1,44 @@
+import { TextResources } from '@/services';
+
+const textResources = new TextResources();
+
+textResources.create('CreateEducationForm.sectionDetails.title', 'Education Details');
+textResources.create('CreateEducationForm.sectionDetails.title', 'Detalhes da Educação', 'pt');
+textResources.create('CreateEducationForm.sectionPeriod.title', 'Period');
+textResources.create('CreateEducationForm.sectionPeriod.title', 'Período', 'pt');
+
+textResources.create('CreateEducationForm.field.institutionName.label', 'Institution Name');
+textResources.create('CreateEducationForm.field.institutionName.label', 'Nome da Instituição', 'pt');
+textResources.create('CreateEducationForm.field.institutionName.placeholder', 'Enter institution name');
+textResources.create('CreateEducationForm.field.institutionName.placeholder', 'Digite o nome da instituição', 'pt');
+
+textResources.create('CreateEducationForm.field.fieldOfStudy.label', 'Field of Study');
+textResources.create('CreateEducationForm.field.fieldOfStudy.label', 'Área de Estudo', 'pt');
+textResources.create('CreateEducationForm.field.fieldOfStudy.placeholder', 'Enter field of study');
+textResources.create('CreateEducationForm.field.fieldOfStudy.placeholder', 'Digite a área de estudo', 'pt');
+
+textResources.create('CreateEducationForm.field.degree.label', 'Degree');
+textResources.create('CreateEducationForm.field.degree.label', 'Grau', 'pt');
+textResources.create('CreateEducationForm.field.degree.placeholder', 'Enter degree');
+textResources.create('CreateEducationForm.field.degree.placeholder', 'Digite o grau', 'pt');
+
+textResources.create('CreateEducationForm.field.grade.label', 'Grade (Optional)');
+textResources.create('CreateEducationForm.field.grade.label', 'Nota (Opcional)', 'pt');
+textResources.create('CreateEducationForm.field.grade.placeholder', 'Enter grade');
+textResources.create('CreateEducationForm.field.grade.placeholder', 'Digite a nota', 'pt');
+
+textResources.create('CreateEducationForm.field.description.label', 'Description (Optional)');
+textResources.create('CreateEducationForm.field.description.label', 'Descrição (Opcional)', 'pt');
+textResources.create('CreateEducationForm.field.description.placeholder', 'Enter description');
+textResources.create('CreateEducationForm.field.description.placeholder', 'Digite a descrição', 'pt');
+
+textResources.create('CreateEducationForm.field.startDate.label', 'Start Date');
+textResources.create('CreateEducationForm.field.startDate.label', 'Data de Início', 'pt');
+
+textResources.create('CreateEducationForm.field.endDate.label', 'End Date');
+textResources.create('CreateEducationForm.field.endDate.label', 'Data de Término', 'pt');
+
+textResources.create('CreateEducationForm.field.submit.label', 'Create Education');
+textResources.create('CreateEducationForm.field.submit.label', 'Criar Educação', 'pt');
+
+export default textResources;

--- a/src/components/forms/educations/CreateEducationForm/CreateEducationForm.tsx
+++ b/src/components/forms/educations/CreateEducationForm/CreateEducationForm.tsx
@@ -1,0 +1,94 @@
+import { Fragment } from 'react';
+import { Card, Container } from '@/components/common';
+import { ContentSidebar } from '@/components/layout';
+import { Form, FormDatePicker, FormInput, FormSubmit } from '@/hooks';
+import { useTextResources } from '@/services/TextResources/TextResourcesProvider';
+import texts from './CreateEducationForm.texts';
+import { CardProps } from '@/components/common/Card/Card.types';
+import { WidgetHeader } from '@/components/headers';
+import { FormValues } from '@/hooks/Form/Form.types';
+import { useAjax } from '@/hooks/useAjax';
+import { EducationData } from '@/types/database.types';
+import { useRouter } from 'next/navigation';
+
+export default function CreateEducationForm() {
+   const { textResources } = useTextResources(texts);
+   const ajax = useAjax();
+   const cardProps: CardProps = { padding: 'm' };
+   const router = useRouter();
+
+   const handleSubmit = async (values: FormValues) => {
+      try {
+         const created = await ajax.post<EducationData>('/education/create', values);
+
+         if (created.error) {
+            throw created;
+         }
+
+         router.push(`/admin/education/${created.data.id}`);
+         return created;
+      } catch (error) {
+         return error;
+      }
+   }
+
+   return (
+      <Form hideSubmit onSubmit={handleSubmit}>
+         <Container>
+            <ContentSidebar>
+               <Fragment>
+                  <WidgetHeader title={textResources.getText('CreateEducationForm.sectionDetails.title')} />
+
+                  <Card {...cardProps}>
+                     <FormInput
+                        fieldName="institution_name"
+                        label={textResources.getText('CreateEducationForm.field.institutionName.label')}
+                        placeholder={textResources.getText('CreateEducationForm.field.institutionName.placeholder')}
+                     />
+                     <FormInput
+                        fieldName="field_of_study"
+                        label={textResources.getText('CreateEducationForm.field.fieldOfStudy.label')}
+                        placeholder={textResources.getText('CreateEducationForm.field.fieldOfStudy.placeholder')}
+                     />
+                     <FormInput
+                        fieldName="degree"
+                        label={textResources.getText('CreateEducationForm.field.degree.label')}
+                        placeholder={textResources.getText('CreateEducationForm.field.degree.placeholder')}
+                     />
+                     <FormInput
+                        fieldName="grade"
+                        label={textResources.getText('CreateEducationForm.field.grade.label')}
+                        placeholder={textResources.getText('CreateEducationForm.field.grade.placeholder')}
+                     />
+                     <FormInput
+                        fieldName="description"
+                        label={textResources.getText('CreateEducationForm.field.description.label')}
+                        placeholder={textResources.getText('CreateEducationForm.field.description.placeholder')}
+                        minRows={5}
+                        multiline
+                     />
+                  </Card>
+               </Fragment>
+
+               <Fragment>
+                  <WidgetHeader title={textResources.getText('CreateEducationForm.sectionPeriod.title')} />
+                  <Card {...cardProps}>
+                     <FormDatePicker
+                        fieldName="start_date"
+                        label={textResources.getText('CreateEducationForm.field.startDate.label')}
+                     />
+                     <FormDatePicker
+                        fieldName="end_date"
+                        label={textResources.getText('CreateEducationForm.field.endDate.label')}
+                     />
+                  </Card>
+
+                  <Card {...cardProps}>
+                     <FormSubmit label={textResources.getText('CreateEducationForm.field.submit.label')} />
+                  </Card>
+               </Fragment>
+            </ContentSidebar>
+         </Container>
+      </Form>
+   );
+}

--- a/src/components/forms/educations/index.tsx
+++ b/src/components/forms/educations/index.tsx
@@ -1,0 +1,1 @@
+export { default as CreateEducationForm } from './CreateEducationForm/CreateEducationForm';


### PR DESCRIPTION
## [FRD-147] Description
This pull request introduces a new "Create Education" feature to the admin section, allowing administrators to add new education records. The main changes include the creation of a dedicated page, form components, and multilingual text resources to support both English and Portuguese.

**Feature Implementation:**

* Added a new page at `src/app/admin/education/create/page.tsx` that renders the education creation interface, including language support.
* Implemented the main content component `EducationCreateContent` and exported it for use in the admin section. [[1]](diffhunk://#diff-72bfe7074abd0ec80f80d6aba309e0013795d31abe16a73b136fe4062b7f6997R1-R21) [[2]](diffhunk://#diff-c12cfdf48558041a6c72204144317b0c4e225b635b8822417bcf2ba6b90b017cR1)

**Form Functionality:**

* Created the `CreateEducationForm` component, which includes form fields for institution name, field of study, degree, grade, description, start date, and end date. The form handles submission, validation, and redirects to the newly created education record upon success.
* Exported the `CreateEducationForm` for use in other parts of the application.

**Internationalization:**

* Added text resource files for both the page content and the form, providing English and Portuguese translations for all user-facing strings. [[1]](diffhunk://#diff-0b215b1d86d5d5d6b7bcf89afda5ea999714711295bedaec988ea4a1fb05e47aR1-R11) [[2]](diffhunk://#diff-db74f34988da4f9163239cb29a27be9cf5daf40ebf7a1ec9f2033e4eb37fafb7R1-R44)

[FRD-147]: https://feliperamosdev.atlassian.net/browse/FRD-147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ