### PR TITLE
[FRD-149] View/Edit Education - Page

### DIFF
--- a/src/app/admin/education/[education_id]/page.tsx
+++ b/src/app/admin/education/[education_id]/page.tsx
@@ -1,0 +1,27 @@
+import { ErrorContent } from '@/components/content';
+import { EducationDetailsContent } from '@/components/content/admin/education';
+import { ErrorContentProps } from '@/components/content/ErrorContent/ErrorContent.types';
+import { AdminPageBase } from '@/components/layout';
+import { headersAcceptLanguage } from '@/helpers';
+import ajax from '@/hooks/useAjax';
+import { EducationData } from '@/types/database.types';
+
+export default async function EducationDetailsPage({ params }: { params: Promise<{ education_id: string }> }) {
+   const { education_id } = await params;
+   const language = await headersAcceptLanguage();
+
+   try {
+      const education = await ajax.get<EducationData>(`/education/${education_id}`, { params: { language_set: language } });
+      if (!education) {
+         return <ErrorContent status={404} message="Education not found" />;
+      }
+
+      return (
+         <AdminPageBase language={language}>
+            <EducationDetailsContent education={education.data as EducationData} />
+         </AdminPageBase>
+      );
+   } catch (error) {
+      return <ErrorContent {...error as ErrorContentProps} />;
+   }
+}

--- a/src/components/content/admin/education/EducationDetailsContent/EducationDetailsContent.texts.ts
+++ b/src/components/content/admin/education/EducationDetailsContent/EducationDetailsContent.texts.ts
@@ -1,0 +1,51 @@
+import { TextResources } from "@/services";
+
+const textResources = new TextResources();
+
+textResources.create('EducationDetailsContent.pageTitle', 'Education Details');
+textResources.create('EducationDetailsContent.pageTitle', 'Detalhes da Educação', 'pt');
+
+textResources.create('EducationDetailsContent.pageDescription', 'View details for this education');
+textResources.create('EducationDetailsContent.pageDescription', 'Veja os detalhes desta educação', 'pt');
+
+textResources.create('EducationDetailsContent.sectionDetails.title', 'Details');
+textResources.create('EducationDetailsContent.sectionDetails.title', 'Detalhes', 'pt');
+
+textResources.create('EducationDetailsContent.fields.id.label', 'ID');
+textResources.create('EducationDetailsContent.fields.id.label', 'ID', 'pt');
+
+textResources.create('EducationDetailsContent.fields.created_at.label', 'Created At');
+textResources.create('EducationDetailsContent.fields.created_at.label', 'Criado em', 'pt');
+
+textResources.create('EducationDetailsContent.fields.updated_at.label', 'Updated At');
+textResources.create('EducationDetailsContent.fields.updated_at.label', 'Atualizado em', 'pt');
+
+textResources.create('EducationDetailsContent.fields.institution_name.label', 'Institution Name');
+textResources.create('EducationDetailsContent.fields.institution_name.label', 'Nome da Instituição', 'pt');
+
+textResources.create('EducationDetailsContent.fields.start_date.label', 'Data de Início');
+textResources.create('EducationDetailsContent.fields.start_date.label', 'Start Date', 'en');
+
+textResources.create('EducationDetailsContent.fields.end_date.label', 'Data de Fim');
+textResources.create('EducationDetailsContent.fields.end_date.label', 'End Date', 'en');
+
+textResources.create('EducationDetailsContent.deleteButton.label', 'Delete Education');
+textResources.create('EducationDetailsContent.deleteButton.label', 'Excluir Educação', 'pt');
+
+// Language sets
+textResources.create('EducationDetailsSet.widgetTitle', 'Language Sets');
+textResources.create('EducationDetailsSet.widgetTitle', 'Conjuntos de Idiomas', 'pt');
+
+textResources.create('EducationDetailsSet.fields.degree.label', 'Degree');
+textResources.create('EducationDetailsSet.fields.degree.label', 'Grau', 'pt');
+
+textResources.create('EducationDetailsSet.fields.grade.label', 'Grade');
+textResources.create('EducationDetailsSet.fields.grade.label', 'Nota', 'pt');
+
+textResources.create('EducationDetailsSet.fields.field_of_study.label', 'Field of Study');
+textResources.create('EducationDetailsSet.fields.field_of_study.label', 'Área de Estudo', 'pt');
+
+textResources.create('EducationDetailsSet.fields.description.label', 'Description');
+textResources.create('EducationDetailsSet.fields.description.label', 'Descrição', 'pt');
+
+export default textResources;

--- a/src/components/content/admin/education/EducationDetailsContent/EducationDetailsContent.texts.ts
+++ b/src/components/content/admin/education/EducationDetailsContent/EducationDetailsContent.texts.ts
@@ -23,11 +23,11 @@ textResources.create('EducationDetailsContent.fields.updated_at.label', 'Atualiz
 textResources.create('EducationDetailsContent.fields.institution_name.label', 'Institution Name');
 textResources.create('EducationDetailsContent.fields.institution_name.label', 'Nome da Instituição', 'pt');
 
-textResources.create('EducationDetailsContent.fields.start_date.label', 'Data de Início');
-textResources.create('EducationDetailsContent.fields.start_date.label', 'Start Date', 'en');
+textResources.create('EducationDetailsContent.fields.start_date.label', 'Start Date');
+textResources.create('EducationDetailsContent.fields.start_date.label', 'Data de Início', 'pt');
 
-textResources.create('EducationDetailsContent.fields.end_date.label', 'Data de Fim');
-textResources.create('EducationDetailsContent.fields.end_date.label', 'End Date', 'en');
+textResources.create('EducationDetailsContent.fields.end_date.label', 'End Date');
+textResources.create('EducationDetailsContent.fields.end_date.label', 'Data de Fim', 'pt');
 
 textResources.create('EducationDetailsContent.deleteButton.label', 'Delete Education');
 textResources.create('EducationDetailsContent.deleteButton.label', 'Excluir Educação', 'pt');

--- a/src/components/content/admin/education/EducationDetailsContent/EducationDetailsContent.tsx
+++ b/src/components/content/admin/education/EducationDetailsContent/EducationDetailsContent.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import { PageHeader, WidgetHeader } from '@/components/headers';
+import { EducationDetailsContentProps } from './EducationDetailsContent.types';
+import EducationDetailsProvider from './EducationDetailsContext';
+import { useTextResources } from '@/services/TextResources/TextResourcesProvider';
+import texts from './EducationDetailsContent.texts';
+import { Card, Container, DateView } from '@/components/common';
+import { ContentSidebar, DataContainer } from '@/components/layout';
+import { Fragment, useState } from 'react';
+import { EditButtons } from '@/components/buttons';
+import { CardProps } from '@/components/common/Card/Card.types';
+import EducationDetailsSets from './subcomponents/EducationDetailsSets';
+import { EditEducationForm } from '@/components/forms/educations';
+import { Form, FormSubmit } from '@/hooks';
+import { useAjax } from '@/hooks/useAjax';
+import { useRouter } from 'next/navigation';
+
+export default function EducationDetailsContent({ education }: EducationDetailsContentProps) {
+   const [editDetails, setEditDetails] = useState<boolean>(false);
+   const { textResources } = useTextResources(texts);
+   const ajax = useAjax();
+   const router = useRouter();
+
+   const cardProps: CardProps = { padding: 'm' };
+
+   const handleDeleteEducation = async () => {
+      try {
+         const deleted = await ajax.delete(`/education/delete`, { data: { education_id: education.id } });
+
+         router.push('/admin');
+         return deleted;
+      } catch (error) {
+         return error;
+      }
+   }
+
+   return (
+      <EducationDetailsProvider education={education}>
+         <div className="EducationDetailsContent">
+            <PageHeader
+               title={textResources.getText('EducationDetailsContent.pageTitle')}
+               description={textResources.getText('EducationDetailsContent.pageDescription')}
+            />
+
+            <Container>
+               <ContentSidebar>
+                  <Fragment>
+                     <Card {...cardProps}>
+                        <WidgetHeader title={textResources.getText('EducationDetailsContent.sectionDetails.title')}>
+                           <EditButtons editMode={editDetails} setEditMode={setEditDetails} />
+                        </WidgetHeader>
+
+                        {editDetails && (
+                           <EditEducationForm />
+                        )}
+
+                        {!editDetails && (<>
+                           <DataContainer>
+                              <label>{textResources.getText('EducationDetailsContent.fields.institution_name.label')}</label>
+                              <p>{education.institution_name}</p>
+                           </DataContainer>
+                           <DataContainer>
+                              <label>{textResources.getText('EducationDetailsContent.fields.start_date.label')}</label>
+                              <DateView date={education.start_date} />
+                           </DataContainer>
+                           <DataContainer>
+                              <label>{textResources.getText('EducationDetailsContent.fields.end_date.label')}</label>
+                              <DateView date={education.end_date} />
+                           </DataContainer>
+                        </>)}
+                     </Card>
+
+                     <EducationDetailsSets cardProps={cardProps} />
+                  </Fragment>
+
+                  <Fragment>
+                     <Card {...cardProps}>
+                        <DataContainer>
+                           <label>{textResources.getText('EducationDetailsContent.fields.id.label')}</label>
+                           <p>{education.id || textResources.getText('EducationDetailsContent.fields.id.placeholder')}</p>
+                        </DataContainer>
+                        <DataContainer vertical>
+                           <label>{textResources.getText('EducationDetailsContent.fields.created_at.label')}</label>
+                           <p>{new Date(education.created_at).toLocaleString()}</p>
+                        </DataContainer>
+                        <DataContainer vertical>
+                           <label>{textResources.getText('EducationDetailsContent.fields.updated_at.label')}</label>
+                           <p>{new Date(education.updated_at || '').toLocaleString()}</p>
+                        </DataContainer>
+                     </Card>
+
+                     <Card {...cardProps}>
+                        <Form onSubmit={handleDeleteEducation} hideSubmit>
+                           <FormSubmit label={textResources.getText('EducationDetailsContent.deleteButton.label')} color="error" />
+                        </Form>
+                     </Card>
+                  </Fragment>
+               </ContentSidebar>
+            </Container>
+         </div>
+      </EducationDetailsProvider>
+   );
+}

--- a/src/components/content/admin/education/EducationDetailsContent/EducationDetailsContent.types.ts
+++ b/src/components/content/admin/education/EducationDetailsContent/EducationDetailsContent.types.ts
@@ -1,0 +1,15 @@
+import { CardProps } from '@/components/common/Card/Card.types';
+import { EducationData } from '@/types/database.types';
+
+export interface EducationDetailsContentProps {
+   education: EducationData;
+}
+
+export interface EducationDetailsContextProps {
+   education: EducationData;
+   children: React.ReactNode;
+}
+
+export interface EducationDetailsSubcomponentProps {
+   cardProps: CardProps;
+}

--- a/src/components/content/admin/education/EducationDetailsContent/EducationDetailsContext.tsx
+++ b/src/components/content/admin/education/EducationDetailsContent/EducationDetailsContext.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { EducationData } from '@/types/database.types';
+import { createContext, useContext } from 'react';
+import { EducationDetailsContextProps } from './EducationDetailsContent.types';
+
+export const EducationDetailsContext = createContext<EducationData | null>(null);
+
+export default function EducationDetailsProvider({ education, children }: EducationDetailsContextProps): React.ReactElement {
+   return (
+      <EducationDetailsContext.Provider value={education}>
+         {children}
+      </EducationDetailsContext.Provider>
+   );
+}
+
+export function useEducationDetails() {
+   const context = useContext(EducationDetailsContext);
+
+   if (context === null) {
+      throw new Error('useEducationDetails must be used within an EducationDetailsProvider');
+   }
+
+   return context;
+}

--- a/src/components/content/admin/education/EducationDetailsContent/subcomponents/EducationDetailsSets.tsx
+++ b/src/components/content/admin/education/EducationDetailsContent/subcomponents/EducationDetailsSets.tsx
@@ -1,0 +1,74 @@
+import { Card, Markdown } from '@/components/common';
+import { EducationDetailsSubcomponentProps } from '../EducationDetailsContent.types';
+import { WidgetHeader } from '@/components/headers';
+import { DataContainer, TabsContent } from '@/components/layout';
+import { TabOption } from '@/components/layout/TabsContent/TabsContent.types';
+import { useEducationDetails } from '../EducationDetailsContext';
+import { EducationSetData } from '@/types/database.types';
+import { useState } from 'react';
+import { languageNames } from '@/app.config';
+import { EditButtons } from '@/components/buttons';
+import { EditEducationSetForm } from '@/components/forms/educations';
+import { useTextResources } from '@/services/TextResources/TextResourcesProvider';
+import texts from '../EducationDetailsContent.texts';
+
+export default function EducationDetailsSets({ cardProps }: EducationDetailsSubcomponentProps): React.ReactElement {
+   const [editMode, setEditMode] = useState<boolean>(false);
+   const { textResources } = useTextResources(texts);
+   const education = useEducationDetails();
+
+   const tabOptions: TabOption[] = education.languageSets?.map((set: EducationSetData) => ({
+      label: languageNames[set.language_set] || textResources.getText('EducationDetailsSet.noSets'),
+      value: set.language_set || 'unknown-language-set',
+   })) || [];
+
+   return (
+      <Card className="EducationDetailsSets" {...cardProps}>
+         <WidgetHeader title={textResources.getText('EducationDetailsSet.widgetTitle')}>
+            <EditButtons
+               editMode={editMode}
+               setEditMode={setEditMode}
+            />
+         </WidgetHeader>
+
+         <TabsContent
+            options={tabOptions}
+         >
+            {tabOptions.map((option: TabOption) => {
+               const languageSet = education.languageSets.find(set => set.language_set === option.value);
+
+               if (!languageSet) {
+                  return null;
+               }
+
+               if (editMode) {
+                  return (
+                     <EditEducationSetForm key={option.value} language_set={option.value} />
+                  );
+               }
+
+               return (
+                  <div key={option.value}>
+                     <DataContainer>
+                        <label>{textResources.getText('EducationDetailsSet.fields.field_of_study.label')}</label>
+                        <p>{languageSet.field_of_study || '---'}</p>
+                     </DataContainer>
+                     <DataContainer>
+                        <label>{textResources.getText('EducationDetailsSet.fields.degree.label')}</label>
+                        <p>{languageSet.degree || '---'}</p>
+                     </DataContainer>
+                     <DataContainer>
+                        <label>{textResources.getText('EducationDetailsSet.fields.grade.label')}</label>
+                        <p>{languageSet.grade || '---'}</p>
+                     </DataContainer>
+                     <DataContainer>
+                        <label>{textResources.getText('EducationDetailsSet.fields.description.label')}</label>
+                        <p>{languageSet.description || '---'}</p>
+                     </DataContainer>
+                  </div>
+               );
+            })}
+         </TabsContent>
+      </Card>
+   );
+}

--- a/src/components/content/admin/education/EducationDetailsContent/subcomponents/EducationDetailsSets.tsx
+++ b/src/components/content/admin/education/EducationDetailsContent/subcomponents/EducationDetailsSets.tsx
@@ -35,7 +35,7 @@ export default function EducationDetailsSets({ cardProps }: EducationDetailsSubc
             options={tabOptions}
          >
             {tabOptions.map((option: TabOption) => {
-               const languageSet = education.languageSets.find(set => set.language_set === option.value);
+               const languageSet = education.languageSets?.find(set => set.language_set === option.value);
 
                if (!languageSet) {
                   return null;

--- a/src/components/content/admin/education/index.tsx
+++ b/src/components/content/admin/education/index.tsx
@@ -1,1 +1,2 @@
 export { default as EducationCreateContent } from './EducationCreateContent/EducationCreateContent';
+export { default as EducationDetailsContent } from './EducationDetailsContent/EducationDetailsContent';

--- a/src/components/forms/educations/EditEducationForm/EditEducationForm.texts.ts
+++ b/src/components/forms/educations/EditEducationForm/EditEducationForm.texts.ts
@@ -1,0 +1,14 @@
+import { TextResources } from '@/services';
+
+const textResources = new TextResources();
+
+textResources.create('EditEducationForm.fields.institution_name.label', 'Institution Name');
+textResources.create('EditEducationForm.fields.institution_name.placeholder', 'Enter institution name');
+
+textResources.create('EditEducationForm.fields.start_date.label', 'Start Date');
+textResources.create('EditEducationForm.fields.start_date.placeholder', 'Select start date');
+
+textResources.create('EditEducationForm.fields.end_date.label', 'End Date');
+textResources.create('EditEducationForm.fields.end_date.placeholder', 'Select end date');
+
+export default textResources;

--- a/src/components/forms/educations/EditEducationForm/EditEducationForm.texts.ts
+++ b/src/components/forms/educations/EditEducationForm/EditEducationForm.texts.ts
@@ -3,12 +3,20 @@ import { TextResources } from '@/services';
 const textResources = new TextResources();
 
 textResources.create('EditEducationForm.fields.institution_name.label', 'Institution Name');
+textResources.create('EditEducationForm.fields.institution_name.label', 'Nome da Instituição', 'pt');
+
 textResources.create('EditEducationForm.fields.institution_name.placeholder', 'Enter institution name');
+textResources.create('EditEducationForm.fields.institution_name.placeholder', 'Digite o nome da instituição', 'pt');
 
 textResources.create('EditEducationForm.fields.start_date.label', 'Start Date');
+textResources.create('EditEducationForm.fields.start_date.label', 'Data de Início', 'pt');
+
 textResources.create('EditEducationForm.fields.start_date.placeholder', 'Select start date');
+textResources.create('EditEducationForm.fields.start_date.placeholder', 'Selecione a data de início', 'pt');
 
 textResources.create('EditEducationForm.fields.end_date.label', 'End Date');
+textResources.create('EditEducationForm.fields.end_date.label', 'Data de Fim', 'pt');
 textResources.create('EditEducationForm.fields.end_date.placeholder', 'Select end date');
+textResources.create('EditEducationForm.fields.end_date.placeholder', 'Selecione a data de fim', 'pt');
 
 export default textResources;

--- a/src/components/forms/educations/EditEducationForm/EditEducationForm.tsx
+++ b/src/components/forms/educations/EditEducationForm/EditEducationForm.tsx
@@ -1,0 +1,41 @@
+import { Form, FormDatePicker, FormInput } from '@/hooks';
+import { useTextResources } from '@/services/TextResources/TextResourcesProvider';
+import { useEducationDetails } from '@/components/content/admin/education/EducationDetailsContent/EducationDetailsContext';
+import texts from './EditEducationForm.texts';
+import { useAjax } from '@/hooks/useAjax';
+import { EducationData } from '@/types/database.types';
+
+export default function EditEducationForm() {
+   const { textResources } = useTextResources(texts);
+   const education = useEducationDetails();
+   const ajax = useAjax();
+
+   const handleSubmit = async (values: any) => {
+      try {
+         const updated = await ajax.patch<EducationData>(`/education/update`, { education_id: education.id, updates: values });
+
+         window.location.reload();
+         return updated;
+      } catch (error) {
+         return error;
+      }
+   }
+
+   return (
+      <Form initialValues={{ ...education }} onSubmit={handleSubmit} editMode>
+         <FormInput
+            fieldName="institution_name"
+            label={textResources.getText('EditEducationForm.fields.institution_name.label')}
+            placeholder={textResources.getText('EditEducationForm.fields.institution_name.placeholder')}
+         />
+         <FormDatePicker
+            fieldName="start_date"
+            label={textResources.getText('EditEducationForm.fields.start_date.label')}
+         />
+         <FormDatePicker
+            fieldName="end_date"
+            label={textResources.getText('EditEducationForm.fields.end_date.label')}
+         />
+      </Form>
+   );
+}

--- a/src/components/forms/educations/EditEducationSetForm/EditEducationSetForm.texts.ts
+++ b/src/components/forms/educations/EditEducationSetForm/EditEducationSetForm.texts.ts
@@ -1,0 +1,28 @@
+import { TextResources } from '@/services';
+
+const textResources = new TextResources();
+
+textResources.create('EditEducationSetForm.title', 'Edit Education Set');
+textResources.create('EditEducationSetForm.title', 'Editar Conjunto de Educação', 'pt');
+
+textResources.create('EditEducationSetForm.fields.field_of_study.label', 'Field of Study');
+textResources.create('EditEducationSetForm.fields.field_of_study.label', 'Área de Estudo', 'pt');
+textResources.create('EditEducationSetForm.fields.field_of_study.placeholder', 'Enter field of study');
+textResources.create('EditEducationSetForm.fields.field_of_study.placeholder', 'Digite a área de estudo', 'pt');
+
+textResources.create('EditEducationSetForm.fields.degree.label', 'Degree');
+textResources.create('EditEducationSetForm.fields.degree.label', 'Grau', 'pt');
+textResources.create('EditEducationSetForm.fields.degree.placeholder', 'Enter degree');
+textResources.create('EditEducationSetForm.fields.degree.placeholder', 'Digite o grau', 'pt');
+
+textResources.create('EditEducationSetForm.fields.grade.label', 'Grade');
+textResources.create('EditEducationSetForm.fields.grade.label', 'Nota', 'pt');
+textResources.create('EditEducationSetForm.fields.grade.placeholder', 'Enter grade');
+textResources.create('EditEducationSetForm.fields.grade.placeholder', 'Digite a nota', 'pt');
+
+textResources.create('EditEducationSetForm.fields.description.label', 'Description');
+textResources.create('EditEducationSetForm.fields.description.label', 'Descrição', 'pt');
+textResources.create('EditEducationSetForm.fields.description.placeholder', 'Enter description');
+textResources.create('EditEducationSetForm.fields.description.placeholder', 'Digite a descrição', 'pt');
+
+export default textResources;

--- a/src/components/forms/educations/EditEducationSetForm/EditEducationSetForm.tsx
+++ b/src/components/forms/educations/EditEducationSetForm/EditEducationSetForm.tsx
@@ -1,0 +1,52 @@
+import { useEducationDetails } from '@/components/content/admin/education/EducationDetailsContent/EducationDetailsContext';
+import { Form, FormInput } from '@/hooks';
+import { useTextResources } from '@/services/TextResources/TextResourcesProvider';
+import texts from './EditEducationSetForm.texts'
+import { useAjax } from '@/hooks/useAjax';
+
+export default function EditEducationSetForm({ language_set }: { language_set: string }) {
+   const education = useEducationDetails();
+   const { textResources } = useTextResources(texts);
+   const ajax = useAjax();
+   const languageSet = education.languageSets?.find(set => set.language_set === language_set);
+
+   const handleUpdate = async (values: any) => {
+      if (!languageSet) return;
+
+      try {
+         const updated = await ajax.patch(`/education/update-set`, { set_id: languageSet.id, updates: values });
+
+         window.location.reload();
+         return updated;
+      } catch (error) {
+         return error;
+      }
+   }
+
+   return (
+      <Form initialValues={{ ...languageSet }} onSubmit={handleUpdate} editMode>
+         <FormInput
+            fieldName="field_of_study"
+            label={textResources.getText('EditEducationSetForm.fields.field_of_study.label')}
+            placeholder={textResources.getText('EditEducationSetForm.fields.field_of_study.placeholder')}
+         />
+         <FormInput
+            fieldName="degree"
+            label={textResources.getText('EditEducationSetForm.fields.degree.label')}
+            placeholder={textResources.getText('EditEducationSetForm.fields.degree.placeholder')}
+         />
+         <FormInput
+            fieldName="grade"
+            label={textResources.getText('EditEducationSetForm.fields.grade.label')}
+            placeholder={textResources.getText('EditEducationSetForm.fields.grade.placeholder')}
+         />
+         <FormInput
+            fieldName="description"
+            minRows={5}
+            multiline
+            label={textResources.getText('EditEducationSetForm.fields.description.label')}
+            placeholder={textResources.getText('EditEducationSetForm.fields.description.placeholder')}
+         />
+      </Form>
+   );
+}

--- a/src/components/forms/educations/index.tsx
+++ b/src/components/forms/educations/index.tsx
@@ -1,1 +1,3 @@
 export { default as CreateEducationForm } from './CreateEducationForm/CreateEducationForm';
+export { default as EditEducationSetForm } from './EditEducationSetForm/EditEducationSetForm';
+export { default as EditEducationForm } from './EditEducationForm/EditEducationForm';

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -98,6 +98,7 @@ export interface EducationData extends EducationSetData {
    end_date: Date;
    is_current: boolean;
    student_id: number;
+   languageSets: EducationSetData[];
 }
 
 export interface EducationSetData extends BasicData {


### PR DESCRIPTION
## [FRD-149] Description
This pull request introduces a comprehensive "Education Details" admin page, enabling viewing, editing, and deleting of education records and their language-specific sets. It adds new UI components, context providers, forms, and internationalized text resources to support these features. The changes are grouped below by theme.

**New Education Details Admin Page**

- Added a new page at `src/app/admin/education/[education_id]/page.tsx` to display details for a specific education record, including error handling and language support. ([src/app/admin/education/[education_id]/page.tsxR1-R27](diffhunk://#diff-5c8a8589920f85c89485e6700b1e8c9ed82bbb6dea806933a9a525a28c1ff7c8R1-R27))
- Implemented the main `EducationDetailsContent` component with context provider, view/edit modes, and delete functionality. [[1]](diffhunk://#diff-25421670e908bd98e6d9de381b50801916bf1def3a077e0e25090568c570b723R1-R104) [[2]](diffhunk://#diff-d56f5ba47cae1694a55e01748343367056dda1fc02e0c34e57eabf4de9b84f6fR1-R25) [[3]](diffhunk://#diff-187d220e0957b84a703806eff32aed0b4727dde720f1d2d8072ff17730c57c25R1-R15) [[4]](diffhunk://#diff-c12cfdf48558041a6c72204144317b0c4e225b635b8822417bcf2ba6b90b017cR2)
- Added a subcomponent `EducationDetailsSets` for managing and editing language-specific education sets via tabs.

**Forms for Editing Education and Sets**

- Added `EditEducationForm` and `EditEducationSetForm` components, allowing admins to edit education and language set details, respectively, with form submission and reload-on-success. [[1]](diffhunk://#diff-3d5dbba4378a4d5aec61885306541c21e229c16b9b3c23ca67bc2be4126931c2R1-R41) [[2]](diffhunk://#diff-24fe86d61a5648bfc25abf97fb1f96ee23a3b7cca6ab8a8b9d79c6ebc266c810R1-R52) [[3]](diffhunk://#diff-f9104a6b27b507d4f8b61140ef86476ac1e1466b1e6852da7e3286b477ac30f3R2-R3)

**Internationalization Support**

- Introduced text resource files for `EducationDetailsContent`, `EditEducationForm`, and `EditEducationSetForm`, supporting English and Portuguese. [[1]](diffhunk://#diff-41f611247b95757289cb449d8a0519ef815b7ce85f3ede02cfe1a7a28a06a06aR1-R51) [[2]](diffhunk://#diff-e87ba9ef503f8d75f9742c95c3fde8df5b7b5f043d2dd1c151802597d25345b6R1-R14) [[3]](diffhunk://#diff-a926ef7aafca550e96879598c2830972415caf705a2c4bc60c62726d4a01c4beR1-R28)

**Data Model Update**

- Updated the `EducationData` type to include a `languageSets` array, supporting multiple localized education sets per record.

[FRD-149]: https://feliperamosdev.atlassian.net/browse/FRD-149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ