### PR TITLE
[FRD-150] Associate Education and Languages with the CV

### DIFF
--- a/src/components/content/admin/curriculum/CVDetailsContent/CVDetailsContent.test.tsx
+++ b/src/components/content/admin/curriculum/CVDetailsContent/CVDetailsContent.test.tsx
@@ -54,6 +54,12 @@ jest.mock('./subcomponents/CVDetailsSidebar', () => ({
   default: () => <div data-testid="cv-details-sidebar">Mock CVDetailsSidebar</div>
 }));
 
+// Mock CVEducations to prevent invalid element type error
+jest.mock('./subcomponents/CVEducations', () => ({
+  __esModule: true,
+  default: () => <div data-testid="cv-educations">Mock CVEducations</div>
+}));
+
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';

--- a/src/components/content/admin/curriculum/CVDetailsContent/CVDetailsContent.text.ts
+++ b/src/components/content/admin/curriculum/CVDetailsContent/CVDetailsContent.text.ts
@@ -44,8 +44,8 @@ textResources.create('CVDetailsSet.noSets', 'No Language Sets Found');
 textResources.create('CVDetailsSet.noSets', 'Nenhum Campo de Idioma Encontrado', 'pt');
 
 // CVDetailsSidebar
-textResources.create('CVDetailsSidebar.pdf.widgetTitle', 'Download PDF');
-textResources.create('CVDetailsSidebar.pdf.widgetTitle', 'Baixar PDF', 'pt');
+textResources.create('CVDetailsSidebar.pdf.widgetTitle', 'PDF');
+textResources.create('CVDetailsSidebar.pdf.widgetTitle', 'PDF', 'pt');
 
 textResources.create('CVDetailsSidebar.pdf.downloadButton.en', 'English');
 textResources.create('CVDetailsSidebar.pdf.downloadButton.en', 'Inglês', 'pt');
@@ -67,6 +67,12 @@ textResources.create('CVDetailsSidebar.skills.widgetTitle', 'Habilidades', 'pt')
 
 textResources.create('CVDetailsSidebar.skills.editButton', 'Edit Curriculum Skills');
 textResources.create('CVDetailsSidebar.skills.editButton', 'Editar Habilidades do Curriculum', 'pt');
+
+textResources.create('CVDetailsSidebar.languages.widgetTitle', 'Languages');
+textResources.create('CVDetailsSidebar.languages.widgetTitle', 'Idiomas', 'pt');
+
+textResources.create('CVDetailsSidebar.languages.noLanguages', 'No Languages Found');
+textResources.create('CVDetailsSidebar.languages.noLanguages', 'Nenhum Idioma Encontrado', 'pt');
 
 textResources.create('CVDetailsSidebar.is_master.text', 'MASTER CV');
 textResources.create('CVDetailsSidebar.is_master.text', 'CV PRINCIPAL', 'pt');

--- a/src/components/content/admin/curriculum/CVDetailsContent/CVDetailsContent.tsx
+++ b/src/components/content/admin/curriculum/CVDetailsContent/CVDetailsContent.tsx
@@ -13,6 +13,7 @@ import CVDetailsSet from './subcomponents/CVDetailsSets';
 import CVExperiences from './subcomponents/CVExperiences';
 import { useTextResources } from '@/services/TextResources/TextResourcesProvider';
 import texts from './CVDetailsContent.text';
+import CVEducations from './subcomponents/CVEducations';
 
 export default function CVDetailsContent({ cv }: CVDetailsContentProps) {
    const cardProps: CardProps = { padding: 'm' };
@@ -32,6 +33,7 @@ export default function CVDetailsContent({ cv }: CVDetailsContentProps) {
                      <CVDetailsInfos cardProps={cardProps} />
                      <CVDetailsSet cardProps={cardProps} />
                      <CVExperiences cardProps={cardProps} />
+                     <CVEducations cardProps={cardProps} />
                   </Fragment>
 
                   <CVDetailsSidebar cardProps={cardProps} />

--- a/src/components/content/admin/curriculum/CVDetailsContent/subcomponents/CVDetailsSidebar.tsx
+++ b/src/components/content/admin/curriculum/CVDetailsContent/subcomponents/CVDetailsSidebar.tsx
@@ -6,7 +6,7 @@ import { useCVDetails } from '../CVDetailsContext';
 import { WidgetHeader } from '@/components/headers';
 import { SkillBadge } from '@/components/badges';
 import { EditButtons } from '@/components/buttons';
-import { EditCVSkillsForm, EditCVMasterForm } from '@/components/forms/curriculums';
+import { EditCVSkillsForm, EditCVMasterForm, EditCVLanguagesForm } from '@/components/forms/curriculums';
 import { useTextResources } from '@/services/TextResources/TextResourcesProvider';
 import texts from '../CVDetailsContent.text';
 import styles from '../CVDetailsContent.module.scss';
@@ -16,15 +16,18 @@ import { useRouter } from 'next/navigation';
 import { Button } from '@mui/material';
 import { cvPDFDownloadLink } from '@/helpers/app.helpers';
 import Link from 'next/link';
+import { LanguageTile } from '@/components/tiles';
 
 export default function CVDetailsSidebar({ cardProps }: CVDetailsSubcomponentProps): React.ReactElement {
    const [editMode, setEditMode] = useState<boolean>(false);
+   const [languagesEdit, setLanguagesEdit] = useState<boolean>(false);
    const [deleteLoading, setDeleteLoading] = useState<boolean>(false);
    const { textResources } = useTextResources(texts);
    const cv = useCVDetails();
    const ajax = useAjax();
    const router = useRouter();
    const cv_skills = cv?.cv_skills || [];
+   const cv_languages = cv?.cv_languages || [];
 
    const handleDelete = async () => {
       const confirmMessage = textResources.getText('CVDetailsSidebar.confirmDelete');
@@ -114,6 +117,26 @@ export default function CVDetailsSidebar({ cardProps }: CVDetailsSubcomponentPro
                {cv_skills.length > 0 && cv_skills.map((skill) => (
                   <SkillBadge key={skill.id} value={skill.name} />
                ))}
+            </div>}
+         </Card>
+
+         <Card {...cardProps}>
+            <WidgetHeader title={textResources.getText('CVDetailsSidebar.languages.widgetTitle')}>
+               <EditButtons
+                  editMode={languagesEdit}
+                  setEditMode={setLanguagesEdit}
+               />
+            </WidgetHeader>
+
+            {languagesEdit && <EditCVLanguagesForm />}
+            {!languagesEdit && <div className="languages-list">
+               {cv_languages.length > 0 ? (
+                  cv_languages.map((lang) => (
+                     <LanguageTile key={lang.id} language={lang} />
+                  ))
+               ) : (
+                  <p>{textResources.getText('CVDetailsSidebar.languages.noLanguages')}</p>
+               )}
             </div>}
          </Card>
 

--- a/src/components/content/admin/curriculum/CVDetailsContent/subcomponents/CVEducations.tsx
+++ b/src/components/content/admin/curriculum/CVDetailsContent/subcomponents/CVEducations.tsx
@@ -1,0 +1,28 @@
+import { Card } from '@/components/common';
+import { useCVDetails } from '../CVDetailsContext';
+import styles from '../CVDetailsContent.module.scss';
+import { CVDetailsSubcomponentProps } from '../CVDetailsContent.types';
+import { WidgetHeader } from '@/components/headers';
+import { EducationTile } from '@/components/tiles';
+import { EditButtons } from '@/components/buttons';
+import { useState } from 'react';
+import { DataContainer } from '@/components/layout';
+import { EditCVEducationsForm } from '@/components/forms/curriculums';
+
+export default function CVEducations({ cardProps }: CVDetailsSubcomponentProps) {
+   const [ editMode, setEditMode ] = useState<boolean>(false);
+   const cv = useCVDetails();
+   const educations = cv?.cv_educations || [];
+
+   return (
+      <Card className={styles.CVEducations} {...cardProps}>
+         <WidgetHeader title="Educations">
+            <EditButtons editMode={editMode} setEditMode={setEditMode} />
+         </WidgetHeader>
+
+         {editMode && <EditCVEducationsForm />}
+         {!editMode && educations.map((education) => <EducationTile key={education.id} education={education} />)}
+         {educations.length === 0 && !editMode && <DataContainer>No educations added yet.</DataContainer>}
+      </Card>
+   );
+}

--- a/src/components/forms/curriculums/EditCVEducationsForm/EditCVEducationsForm.texts.ts
+++ b/src/components/forms/curriculums/EditCVEducationsForm/EditCVEducationsForm.texts.ts
@@ -1,0 +1,8 @@
+import { TextResources } from '@/services';
+
+const textResources = new TextResources();
+
+textResources.create('EditCVEducationsForm.saveButton', 'Save Changes');
+textResources.create('EditCVEducationsForm.saveButton', 'Salvar Alterações', 'pt');
+
+export default textResources;

--- a/src/components/forms/curriculums/EditCVEducationsForm/EditCVEducationsForm.tsx
+++ b/src/components/forms/curriculums/EditCVEducationsForm/EditCVEducationsForm.tsx
@@ -1,0 +1,49 @@
+import { useCVDetails } from '@/components/content/admin/curriculum/CVDetailsContent/CVDetailsContext';
+import { loadEducationsOptions } from '@/helpers/database.helpers';
+import { Form } from '@/hooks';
+import FormCheckboxList from '@/hooks/Form/inputs/FormCheckboxList';
+import { useAjax } from '@/hooks/useAjax';
+import { useTextResources } from '@/services/TextResources/TextResourcesProvider';
+import texts from './EditCVEducationsForm.texts'
+import { FormValues } from '@/hooks/Form/Form.types';
+import { CVData } from '@/types/database.types';
+
+export default function EditCVEducationsForm(): React.ReactElement {
+   const cv = useCVDetails();
+   const { textResources } = useTextResources(texts);
+   const ajax = useAjax();
+   const educations = cv?.cv_educations || [];
+
+   if (!cv) {
+      return <></>;
+   }
+
+   const handleSubmit = async (values: FormValues) => {
+      try {
+         const response = await ajax.post<CVData>('/curriculum/update', { id: cv.id, updates: values });
+
+         if (response.error) {
+            throw response;
+         }
+
+         window.location.reload();
+         return response;
+      } catch (error) {
+         return error;
+      }
+   }
+
+   return (
+      <Form
+         onSubmit={handleSubmit}
+         submitLabel={textResources.getText('EditCVEducationsForm.saveButton')}
+         initialValues={{ cv_educations: educations.map(edu => edu.id) }}
+         editMode
+      >
+         <FormCheckboxList
+            fieldName="cv_educations"
+            loadOptions={async () => await loadEducationsOptions(ajax, textResources.currentLanguage)}
+         />
+      </Form>
+   );
+}

--- a/src/components/forms/curriculums/EditCVLanguagesForm/EditCVLanguagesForm.texts.ts
+++ b/src/components/forms/curriculums/EditCVLanguagesForm/EditCVLanguagesForm.texts.ts
@@ -1,0 +1,8 @@
+import { TextResources } from '@/services';
+
+const textResources = new TextResources();
+
+textResources.create('EditCVLanguagesForm.saveButton', 'Save Changes');
+textResources.create('EditCVLanguagesForm.saveButton', 'Salvar Alterações', 'pt');
+
+export default textResources;

--- a/src/components/forms/curriculums/EditCVLanguagesForm/EditCVLanguagesForm.tsx
+++ b/src/components/forms/curriculums/EditCVLanguagesForm/EditCVLanguagesForm.tsx
@@ -1,0 +1,49 @@
+import { useCVDetails } from '@/components/content/admin/curriculum/CVDetailsContent/CVDetailsContext';
+import { loadLanguagesOptions } from '@/helpers/database.helpers';
+import { Form } from '@/hooks';
+import FormCheckboxList from '@/hooks/Form/inputs/FormCheckboxList';
+import { useAjax } from '@/hooks/useAjax';
+import { useTextResources } from '@/services/TextResources/TextResourcesProvider';
+import texts from './EditCVLanguagesForm.texts'
+import { FormValues } from '@/hooks/Form/Form.types';
+import { CVData } from '@/types/database.types';
+
+export default function EditCVLanguagesForm(): React.ReactElement {
+   const cv = useCVDetails();
+   const { textResources } = useTextResources(texts);
+   const ajax = useAjax();
+   const languages = cv?.cv_languages || [];
+
+   if (!cv) {
+      return <></>;
+   }
+
+   const handleSubmit = async (values: FormValues) => {
+      try {
+         const response = await ajax.post<CVData>('/curriculum/update', { id: cv.id, updates: values });
+
+         if (response.error) {
+            throw response;
+         }
+
+         window.location.reload();
+         return response;
+      } catch (error) {
+         return error;
+      }
+   }
+
+   return (
+      <Form
+         onSubmit={handleSubmit}
+         submitLabel={textResources.getText('EditCVLanguagesForm.saveButton')}
+         initialValues={{ cv_languages: languages.map(lang => lang.id) }}
+         editMode
+      >
+         <FormCheckboxList
+            fieldName="cv_languages"
+            loadOptions={async () => await loadLanguagesOptions(ajax, textResources.currentLanguage)}
+         />
+      </Form>
+   );
+}

--- a/src/components/forms/curriculums/index.tsx
+++ b/src/components/forms/curriculums/index.tsx
@@ -4,3 +4,5 @@ export { default as EditCVInfosForm } from './EditCVInfosForm/EditCVInfosForm';
 export { default as EditCVMasterForm } from './EditCVMasterForm/EditCVMasterForm';
 export { default as EditCVSetForm } from './EditCVSetForm/EditCVSetForm';
 export { default as EditCVSkillsForm } from './EditCVSkillsForm/EditCVSkillsForm';
+export { default as EditCVLanguagesForm } from './EditCVLanguagesForm/EditCVLanguagesForm';
+export { default as EditCVEducationsForm } from './EditCVEducationsForm/EditCVEducationsForm';

--- a/src/components/tiles/EducationTile/EducationTile.module.scss
+++ b/src/components/tiles/EducationTile/EducationTile.module.scss
@@ -1,0 +1,26 @@
+@use '@/style/variables' as *;
+
+.EducationTile {
+   background-color: $background-dark;
+   border-left: 3px solid $primary;
+   cursor: pointer;
+   -webkit-user-select: none;
+   user-select: none;
+
+   .tileTitle {
+      font-size: 0.95rem;
+      font-weight: 600;
+   }
+
+   .tileSubTitle {
+      font-size: 0.8rem;
+      font-weight: 400;
+      color: $text-soft;
+   }
+
+   .educationDate {
+      font-size: 0.8rem;
+      font-weight: 400;
+      color: $text-soft;
+   }
+}

--- a/src/components/tiles/EducationTile/EducationTile.tsx
+++ b/src/components/tiles/EducationTile/EducationTile.tsx
@@ -1,0 +1,27 @@
+import { Card, DateView } from '@/components/common';
+import { EducationTileProps } from './EducationTile.types';
+import { parseCSS } from '@/helpers/parse.helpers';
+import styles from './EducationTile.module.scss';
+import { useRouter } from 'next/navigation';
+
+export default function EducationTile({ education, className }: EducationTileProps) {
+   const router = useRouter();
+   const CSS = parseCSS(className, [
+      'EducationTile',
+      styles.EducationTile
+   ]);
+
+   return (
+      <Card className={CSS} padding="s" elevation="none" onClick={() => router.push(`/admin/education/${education.id}`)}>
+         <span className={styles.tileTitle}>
+            {education.field_of_study} at {education.institution_name}
+         </span>
+         <p className={styles.educationDate}>
+            <DateView date={education.start_date} /> - <DateView date={education.end_date} />
+         </p>
+         <p className={styles.tileSubTitle}>
+            {education.degree}
+         </p>
+      </Card>
+   );
+}

--- a/src/components/tiles/EducationTile/EducationTile.types.ts
+++ b/src/components/tiles/EducationTile/EducationTile.types.ts
@@ -1,0 +1,6 @@
+import { EducationData } from "@/types/database.types";
+
+export interface EducationTileProps {
+   education: EducationData;
+   className?: string | string[];
+}

--- a/src/components/tiles/LanguageTile/LanguageTile.module.scss
+++ b/src/components/tiles/LanguageTile/LanguageTile.module.scss
@@ -1,0 +1,24 @@
+@use '@/style/variables' as *;
+
+.LanguageTile {
+   padding: $padding-s;
+   background-color: $background-dark;
+   border-radius: $radius-s;
+   cursor: pointer;
+   -webkit-user-select: none;
+   user-select: none;
+
+   &:not(:last-child) {
+      margin-bottom: 0.5rem;
+   }
+
+   .languageName {
+      font-size: 0.9rem;
+      font-weight: 600;
+   }
+
+   .languageLevel {
+      font-size: 0.8rem;
+      color: $text-soft;
+   }
+}

--- a/src/components/tiles/LanguageTile/LanguageTile.tsx
+++ b/src/components/tiles/LanguageTile/LanguageTile.tsx
@@ -1,0 +1,20 @@
+import { parseCSS } from '@/helpers/parse.helpers';
+import { LanguageTileProps } from './LanguageTile.types';
+import styles from './LanguageTile.module.scss'
+import { useRouter } from 'next/navigation';
+
+export default function LanguageTile({ language, className }: LanguageTileProps) {
+   const router = useRouter();
+
+   const CSS = parseCSS(className, [
+      'LanguageTile',
+      styles.LanguageTile
+   ]);
+
+   return (
+      <div className={CSS} onClick={() => router.push(`/admin/language/${language.id}`)}>
+         <span className={styles.languageName}>{language.default_name}</span>
+         <p className={styles.languageLevel}>{language.local_name}</p>
+      </div>
+   );
+}  

--- a/src/components/tiles/LanguageTile/LanguageTile.types.ts
+++ b/src/components/tiles/LanguageTile/LanguageTile.types.ts
@@ -1,0 +1,6 @@
+import { LanguageData } from "@/types/database.types";
+
+export interface LanguageTileProps {
+   language: LanguageData;
+   className?: string | string[];
+}

--- a/src/components/tiles/index.tsx
+++ b/src/components/tiles/index.tsx
@@ -1,3 +1,5 @@
 export { default as ExperienceTile } from './ExperienceTile/ExperienceTile';
 export { default as ErrorTile } from './ErrorTile/ErrorTile';
 export { default as CVTile } from './CVTile/CVTile';
+export { default as LanguageTile } from './LanguageTile/LanguageTile';
+export { default as EducationTile } from './EducationTile/EducationTile';

--- a/src/helpers/database.helpers.ts
+++ b/src/helpers/database.helpers.ts
@@ -1,7 +1,7 @@
 import { FormCheckboxOption, FormSelectOption, FormValues } from "@/hooks/Form/Form.types";
 import { TextResources, UserData } from "@/services";
 import Ajax from "@/services/Ajax/Ajax";
-import { CompanyData, ExperienceData, SkillData } from "@/types/database.types";
+import { CompanyData, EducationData, ExperienceData, LanguageData, SkillData } from "@/types/database.types";
 
 export const handleExperienceUpdate = async (ajax: Ajax, experience: ExperienceData, values: Partial<ExperienceData>) => {
    if (!values || !Object.keys(values).length) {
@@ -72,6 +72,44 @@ export async function loadExperiencesListOptions(ajax: Ajax, language_set: strin
       }));
    } catch (error) {
       console.error("Error loading experiences list options:", error);
+      throw error;
+   }
+}
+
+export async function loadLanguagesOptions(ajax: Ajax, language_set: string): Promise<FormCheckboxOption[]> {
+   try {
+      const response = await ajax.get<LanguageData[]>('/user/languages', { params: { language_set } });
+
+      if (!response.success) {
+         throw new Error("Failed to load languages");
+      }
+
+      return response.data.map((item) => ({
+         id: item.id,
+         primary: item.default_name,
+         secondary: item.level,
+      }));
+   } catch (error) {
+      console.error("Error loading languages options:", error);
+      throw error;
+   }
+}
+
+export async function loadEducationsOptions(ajax: Ajax, language_set: string): Promise<FormCheckboxOption[]> {
+   try {
+      const response = await ajax.get<EducationData[]>('/user/educations', { params: { language_set } });
+
+      if (!response.success) {
+         throw new Error("Failed to load educations");
+      }
+
+      return response.data.map((item) => ({
+         id: item.id,
+         primary: item.institution_name,
+         secondary: item.field_of_study,
+      }));
+   } catch (error) {
+      console.error("Error loading educations options:", error);
       throw error;
    }
 }

--- a/src/hooks/Form/inputs/FormCheckboxList.tsx
+++ b/src/hooks/Form/inputs/FormCheckboxList.tsx
@@ -8,7 +8,7 @@ import { Card } from '@/components/common';
 
 export default function FormCheckboxList({ className, label, fieldName, options = [], loadOptions }: FormCheckboxListProps) {
    const { getValue, setFieldValue } = useForm();
-   const [ optionState, setOptionState ] = useState(options);
+   const [optionState, setOptionState] = useState(options);
 
    const CSS = parseCSS(className, [
       'FormCheckboxList'
@@ -22,7 +22,7 @@ export default function FormCheckboxList({ className, label, fieldName, options 
       }).catch((error) => {
          console.error("Error loading options for FormCheckboxList:", error);
       });
-   }, [ loadOptions ]);
+   }, [loadOptions]);
 
    if (!fieldName) {
       console.error("FormCheckboxList: fieldName is required");
@@ -34,7 +34,7 @@ export default function FormCheckboxList({ className, label, fieldName, options 
 
    const handleChange = ({ target: { checked } }: React.ChangeEvent<HTMLInputElement>, id: number) => {
       if (checked && !isChecked(id)) {
-         setFieldValue(fieldName, [ ...values, id ]);
+         setFieldValue(fieldName, [...values, id]);
       } else {
          setFieldValue(fieldName, values.filter((value) => value !== id));
       }
@@ -81,12 +81,14 @@ export default function FormCheckboxList({ className, label, fieldName, options 
                      }
                   >
                      <ListItemButton>
-                        <ListItemAvatar>
-                           <Avatar
-                              alt={`Avatar ${value.primary}`}
-                              src={value.avatarUrl}
-                           />
-                        </ListItemAvatar>
+                        {value.avatarUrl && (
+                           <ListItemAvatar>
+                              <Avatar
+                                 alt={`Avatar ${value.primary}`}
+                                 src={value.avatarUrl}
+                              />
+                           </ListItemAvatar>
+                        )}
 
                         <ListItemText
                            id={labelId}

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -68,6 +68,8 @@ export interface CVData extends CVSetData {
    notes?: string;
    cv_experiences?: ExperienceData[];
    cv_skills?: SkillData[];
+   cv_languages?: LanguageData[];
+   cv_educations?: EducationData[];
    languageSets: CVSetData[];
    cv_owner_id: number;
 }
@@ -86,6 +88,7 @@ export interface LanguageData extends BasicData {
    default_name: string;
    local_name: string;
    locale_code: string;
+   level: string;
    reading_level: string;
    writing_level: string;
    speaking_level: string;


### PR DESCRIPTION
## [FRD-150] Description
This pull request adds support for managing and displaying languages and educations within the CV details admin UI. It introduces new sidebar widgets for both, allows editing via checkbox forms, and adds reusable tiles for visualizing language and education data. Supporting helper functions and translations are also included.

**CV Details Page Enhancements:**

* Added new sidebar widgets for "Languages" and "Educations", each with view and edit modes, including "no items found" states and localized text resources. [[1]](diffhunk://#diff-c27f29a4082eee5a9afe82fe211fae29d2299ecf6d7f2e1b3d4bfc9fd05edd59R123-R142) [[2]](diffhunk://#diff-90e89e78c7f88564009066369475b9c805ebb45e2c12aac0c2a9872cad4a9fa8R71-R76) [[3]](diffhunk://#diff-96d770149da47f24cc5b90774f365c92bc8d479b6d6c5efb8f324d5780501bd6R36) [[4]](diffhunk://#diff-2a09442868b5ee3233fa2dd718a99e01246f9d2ecaccf4abee49fcc460fcc75bR1-R28) [[5]](diffhunk://#diff-96d770149da47f24cc5b90774f365c92bc8d479b6d6c5efb8f324d5780501bd6R16) [[6]](diffhunk://#diff-90e89e78c7f88564009066369475b9c805ebb45e2c12aac0c2a9872cad4a9fa8L47-R48)

**Forms and Editing:**

* Implemented `EditCVLanguagesForm` and `EditCVEducationsForm` components, allowing users to update the languages and educations associated with a CV using checkbox lists populated from the backend. Added corresponding text resources for form labels and buttons. [[1]](diffhunk://#diff-a64f1d892ddb14f59baee6acf1c3b88416c2a710879b73748cbadb570a4b2f88R1-R49) [[2]](diffhunk://#diff-f3096bed946f7c6ea26cce5bd0eca6d48cb7f906f92d7e0f58824fb43ca76d7dR1-R8) [[3]](diffhunk://#diff-663558ae9d638dfdc6aa5da33a5f4acd8979ce922825633fb5da1b98c141335cR1-R49) [[4]](diffhunk://#diff-4f5eaa8de24b5d5ca8a372a1126c4c688b8b0e24321ea069564ee0a973ad31c1R1-R8) [[5]](diffhunk://#diff-f7dca03ecd1c69649392b250963afed0436bf16c53c8da7fb21e59b12c0d62b4R7-R8)

**Reusable Tiles and Styling:**

* Added `LanguageTile` and `EducationTile` components for consistent display of language and education items, with navigation on click. Introduced associated SCSS modules for styling and type definitions. [[1]](diffhunk://#diff-4a9a5edb951d416f9b74ef12b5c6513b2c3adc4c38da7108deaa25e6108d58e8R1-R20) [[2]](diffhunk://#diff-14e3f670d4620e75bddfd5a2dde11caacf4e54664a2c6ecdde6f149fd49e41abR1-R6) [[3]](diffhunk://#diff-ed5812817525dda02bae20b5160131218cb222d38c1c671e316ce569876ba160R1-R24) [[4]](diffhunk://#diff-d2fe494b7640ed8342475e9fee40151c73fe9cdf4f91b1a824037e6461e89f4aR1-R27) [[5]](diffhunk://#diff-bc92a58e56df19071f9ad9bda7169ce9c4321bd9e9b0bcb8728d3b9d83882a66R1-R6) [[6]](diffhunk://#diff-1a62debcd21e1f2ecc5aae80e51a879859983fa5669bc4eb2cc82bb7d166ba2bR1-R26) [[7]](diffhunk://#diff-36df951f9b909c75099ee1a1a62811ce67527fa27963f1779117cbfe03a1c917R4-R5)

**Backend Integration and Data Structures:**

* Extended the `CVData` type to include `cv_languages` and `cv_educations`. Added helper functions `loadLanguagesOptions` and `loadEducationsOptions` for fetching selectable options from the backend. [[1]](diffhunk://#diff-5b215ddbe1da343b227002e728f9ac8e6d4e3f3579f095d7872deff8061a92b9R71-R72) [[2]](diffhunk://#diff-0716a1c2a7aabef86cfe340116f382528a8e28774b3824945b7cf6d133021133L4-R4) [[3]](diffhunk://#diff-0716a1c2a7aabef86cfe340116f382528a8e28774b3824945b7cf6d133021133R79-R116)

**UI/UX Improvements:**

* Updated `FormCheckboxList` to conditionally display avatars if present, improving option clarity in forms.

[FRD-150]: https://feliperamosdev.atlassian.net/browse/FRD-150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ