### PR TITLE
[FRD-151] Display Education and Languages on PDF

### DIFF
--- a/src/components/content/curriculum/CVPDFTemplateContent/CVPDFTemplateContent.module.scss
+++ b/src/components/content/curriculum/CVPDFTemplateContent/CVPDFTemplateContent.module.scss
@@ -192,7 +192,7 @@
    }
    
    .CVPDFExperiences {
-      .experienceItem {
+      .experienceItem:not(:last-child) {
          border-bottom: 2px dotted $text-soft;
       }
 
@@ -236,6 +236,55 @@
          h4 {
             margin-top: 0.5rem;
             margin-bottom: 0.25rem;
+         }
+      }
+   }
+
+   .CVPDFEducation {
+      .educationList {
+         margin-top: 1.5rem;
+
+         .educationItem {
+            padding: $padding-s;
+            border-left: 3px solid $primary;
+            border-radius: $radius-s;
+
+            .fieldOfStudy {
+               font-size: 1.05rem;
+            }
+
+            .description {
+               font-size: 0.9rem;
+            }
+         }
+      }
+   }
+
+   .CVPDFLanguages {
+      .languageList {
+         margin-top: 1.5rem;
+
+         .languageItem {
+            display: inline-flex;
+            padding: $padding-s;
+            border-left: 3px solid $primary;
+            border-radius: $radius-s;
+            margin-right: 1rem;
+
+            .languageTitle {
+               font-size: 1rem;
+               font-weight: 600;
+            }
+
+            .proficiency {
+               li {
+                  display: inline-block;
+
+                  h4 {
+                     font-size: 0.9rem;
+                  }
+               }
+            }
          }
       }
    }

--- a/src/components/content/curriculum/CVPDFTemplateContent/CVPDFTemplateContent.test.tsx
+++ b/src/components/content/curriculum/CVPDFTemplateContent/CVPDFTemplateContent.test.tsx
@@ -68,6 +68,18 @@ jest.mock('./sections/CVPDFSummary', () => {
    };
 });
 
+jest.mock('./sections/CVPDFEducation', () => {
+   return function MockCVPDFEducation() {
+      return <div data-testid="cv-pdf-education">CV PDF Education</div>;
+   };
+});
+
+jest.mock('./sections/CVPDFLanguages', () => {
+   return function MockCVPDFLanguages() {
+      return <div data-testid="cv-pdf-languages">CV PDF Languages</div>;
+   };
+});
+
 const mockCVData: CVData = {
    id: 1,
    title: 'Senior Developer CV',
@@ -105,6 +117,8 @@ describe('CVPDFTemplateContent', () => {
       expect(screen.getByTestId('cv-pdf-header')).toBeInTheDocument();
       expect(screen.getByTestId('cv-pdf-skills')).toBeInTheDocument();
       expect(screen.getByTestId('cv-pdf-experiences')).toBeInTheDocument();
+      expect(screen.getByTestId('cv-pdf-education')).toBeInTheDocument();
+      expect(screen.getByTestId('cv-pdf-languages')).toBeInTheDocument();
    });
 
    it('passes CV data to the provider correctly', () => {
@@ -134,12 +148,14 @@ describe('CVPDFTemplateContent', () => {
       const mainDiv = container.querySelector('div[class*="CVPDFTemplateContent"]');
       const sectionElements = mainDiv?.children;
       
-      expect(sectionElements).toHaveLength(5);
+      expect(sectionElements).toHaveLength(7);
       expect(sectionElements?.[0]).toHaveAttribute('data-testid', 'cv-pdf-header');
       expect(sectionElements?.[1]).toHaveAttribute('data-testid', 'cv-pdf-contact');
       expect(sectionElements?.[2]).toHaveAttribute('data-testid', 'cv-pdf-summary');
       expect(sectionElements?.[3]).toHaveAttribute('data-testid', 'cv-pdf-skills');
       expect(sectionElements?.[4]).toHaveAttribute('data-testid', 'cv-pdf-experiences');
+      expect(sectionElements?.[5]).toHaveAttribute('data-testid', 'cv-pdf-education');
+      expect(sectionElements?.[6]).toHaveAttribute('data-testid', 'cv-pdf-languages');
    });
 
    it('handles minimal CV data', () => {
@@ -166,6 +182,8 @@ describe('CVPDFTemplateContent', () => {
       expect(screen.getByTestId('cv-pdf-header')).toBeInTheDocument();
       expect(screen.getByTestId('cv-pdf-skills')).toBeInTheDocument();
       expect(screen.getByTestId('cv-pdf-experiences')).toBeInTheDocument();
+      expect(screen.getByTestId('cv-pdf-education')).toBeInTheDocument();
+      expect(screen.getByTestId('cv-pdf-languages')).toBeInTheDocument();
    });
 
    it('provides CV context to child components', () => {
@@ -255,6 +273,8 @@ describe('CVPDFTemplateContent', () => {
       expect(screen.getByTestId('cv-pdf-header')).toBeInTheDocument();
       expect(screen.getByTestId('cv-pdf-skills')).toBeInTheDocument();
       expect(screen.getByTestId('cv-pdf-experiences')).toBeInTheDocument();
+      expect(screen.getByTestId('cv-pdf-education')).toBeInTheDocument();
+      expect(screen.getByTestId('cv-pdf-languages')).toBeInTheDocument();
    });
 
    it('maintains component structure with user data', () => {
@@ -280,6 +300,8 @@ describe('CVPDFTemplateContent', () => {
       expect(screen.getByTestId('cv-pdf-header')).toBeInTheDocument();
       expect(screen.getByTestId('cv-pdf-skills')).toBeInTheDocument();
       expect(screen.getByTestId('cv-pdf-experiences')).toBeInTheDocument();
+      expect(screen.getByTestId('cv-pdf-education')).toBeInTheDocument();
+      expect(screen.getByTestId('cv-pdf-languages')).toBeInTheDocument();
    });
 
    it('handles master CV flag correctly', () => {
@@ -297,5 +319,7 @@ describe('CVPDFTemplateContent', () => {
       expect(screen.getByTestId('cv-pdf-header')).toBeInTheDocument();
       expect(screen.getByTestId('cv-pdf-skills')).toBeInTheDocument();
       expect(screen.getByTestId('cv-pdf-experiences')).toBeInTheDocument();
+      expect(screen.getByTestId('cv-pdf-education')).toBeInTheDocument();
+      expect(screen.getByTestId('cv-pdf-languages')).toBeInTheDocument();
    });
 });

--- a/src/components/content/curriculum/CVPDFTemplateContent/CVPDFTemplateContent.tsx
+++ b/src/components/content/curriculum/CVPDFTemplateContent/CVPDFTemplateContent.tsx
@@ -9,6 +9,8 @@ import { parseCSS } from '@/helpers/parse.helpers';
 import styles from './CVPDFTemplateContent.module.scss';
 import CVPDFContact from './sections/CVPDFContact';
 import CVPDFSummary from './sections/CVPDFSummary';
+import CVPDFEducation from './sections/CVPDFEducation';
+import CVPDFLanguages from './sections/CVPDFLanguages';
 
 export default function CVPDFTemplateContent({ cv }: CVPDFTemplateContentProps): React.ReactElement {
    const CSS = parseCSS('CVPDFTemplateContent', styles.CVPDFTemplateContent);
@@ -21,6 +23,8 @@ export default function CVPDFTemplateContent({ cv }: CVPDFTemplateContentProps):
             <CVPDFSummary />
             <CVPDFSkills />
             <CVPDFExperiences />
+            <CVPDFEducation />
+            <CVPDFLanguages />
          </div>
       </CVPDFTemplateProvider>
    );

--- a/src/components/content/curriculum/CVPDFTemplateContent/CVPDFTemplateContext.text.ts
+++ b/src/components/content/curriculum/CVPDFTemplateContent/CVPDFTemplateContext.text.ts
@@ -105,4 +105,12 @@ textResources.create('CVPDFSkills.skills.cloud', 'Serviços de Nuvem', 'pt');
 textResources.create('CVPDFSkills.skills.others', 'Others');
 textResources.create('CVPDFSkills.skills.others', 'Outros', 'pt');
 
+// CVPDFEducation
+textResources.create('CVPDFEducation.title', 'Education');
+textResources.create('CVPDFEducation.title', 'Educação', 'pt');
+
+// CVPDFLanguages
+textResources.create('CVPDFLanguages.title', 'Languages');
+textResources.create('CVPDFLanguages.title', 'Idiomas', 'pt');
+
 export default textResources;

--- a/src/components/content/curriculum/CVPDFTemplateContent/sections/CVPDFEducation.tsx
+++ b/src/components/content/curriculum/CVPDFTemplateContent/sections/CVPDFEducation.tsx
@@ -1,0 +1,33 @@
+import { Container, DateView, Markdown } from '@/components/common';
+import styles from '../CVPDFTemplateContent.module.scss';
+import { useTextResources } from '@/services/TextResources/TextResourcesProvider';
+import { useCVPDFTemplate } from '../CVPDFTemplateContext';
+
+export default function CVPDFEducation() {
+   const { textResources } = useTextResources();
+   const cv = useCVPDFTemplate();
+   const educations = cv.cv_educations || [];
+
+   return (
+      <section className={styles.CVPDFEducation}>
+         <Container fullwidth>
+            <h2>{textResources.getText('CVPDFEducation.title')}</h2>
+            <hr />
+
+            <ul className={styles.educationList}>
+               {educations.map((education) => (
+                  <li key={education.id} className={styles.educationItem}>
+                     <h3>{education.institution_name}</h3>
+                     <p className={styles.fieldOfStudy}>{education.field_of_study}</p>
+                     <p><DateView date={education.start_date} /> - <DateView date={education.end_date} /></p>
+
+                     {education.description && (
+                        <Markdown className={styles.description} value={education.description} />
+                     )}
+                  </li>
+               ))}
+            </ul>
+         </Container>
+      </section>
+   );
+}

--- a/src/components/content/curriculum/CVPDFTemplateContent/sections/CVPDFExperience.tsx
+++ b/src/components/content/curriculum/CVPDFTemplateContent/sections/CVPDFExperience.tsx
@@ -71,7 +71,7 @@ export default function CVPDFExperiences(): React.ReactElement {
                               </Link>
                            )}
 
-                           <ul title={textResources.getText('CVPDFExperiences.experienceItem.skillsLabel')} className={styles.chipsList}>
+                           <ul className={styles.chipsList}>
                               {experience.skills?.map((skill, index) => (
                                  <li key={index}>{skill.name}</li>
                               ))}

--- a/src/components/content/curriculum/CVPDFTemplateContent/sections/CVPDFLanguages.tsx
+++ b/src/components/content/curriculum/CVPDFTemplateContent/sections/CVPDFLanguages.tsx
@@ -1,0 +1,28 @@
+import { useTextResources } from '@/services/TextResources/TextResourcesProvider';
+import { useCVPDFTemplate } from '../CVPDFTemplateContext';
+import styles from '../CVPDFTemplateContent.module.scss';
+import { Container } from '@/components/common';
+
+export default function CVPDFLanguages() {
+   const { textResources } = useTextResources();
+   const cv = useCVPDFTemplate();
+   const languages = cv.cv_languages || [];
+
+   return (
+      <section className={styles.CVPDFLanguages}>
+         <Container fullwidth>
+            <h2>{textResources.getText('CVPDFLanguages.title')}</h2>
+            <hr />
+
+            <ul className={styles.languageList}>
+               {languages.map((language) => (
+                  <li key={language.id} className={styles.languageItem}>
+                     <span className={styles.languageTitle}>{language.default_name}</span>
+                     <p>{language.level}</p>
+                  </li>
+               ))}
+            </ul>
+         </Container>
+      </section>
+   );
+}


### PR DESCRIPTION
## [FRD-151] Description
This pull request adds new Education and Languages sections to the CV PDF template, updates styling to support these sections, and improves the overall structure and internationalization of the curriculum PDF content. The most important changes are grouped below.

**New Sections and Components:**

* Added the `CVPDFEducation` and `CVPDFLanguages` components to display education history and language skills in the CV PDF template, including their integration into the main `CVPDFTemplateContent` component. [[1]](diffhunk://#diff-3a430ee0f9d9678a515204f75f066817aee19ed50aafa32fe6507e499022493fR1-R33) [[2]](diffhunk://#diff-55bada8eeca26182af4f677e0605b52f3f4f582fa73d7a3451d5e4882eba32efR1-R28) [[3]](diffhunk://#diff-895a965a37997983a31d16a2c2f34c4e6827288fbf63f30c9e8acfc79ce2b596R12-R13) [[4]](diffhunk://#diff-895a965a37997983a31d16a2c2f34c4e6827288fbf63f30c9e8acfc79ce2b596R26-R27)

**Styling Updates:**

* Updated `CVPDFTemplateContent.module.scss` to add styles for the new Education and Languages sections, and improved the experience item border to only show on non-last items. [[1]](diffhunk://#diff-6edc5c48eb59d1ea777c72db171e08dcb6ca5e5b13eb70cce56d947ad24f4801L195-R195) [[2]](diffhunk://#diff-6edc5c48eb59d1ea777c72db171e08dcb6ca5e5b13eb70cce56d947ad24f4801R242-R290)

**Internationalization:**

* Added text resources for the new Education and Languages section titles in both English and Portuguese.

**Minor Improvements:**

* Cleaned up the experience skills list by removing an unnecessary `title` attribute.

[FRD-151]: https://feliperamosdev.atlassian.net/browse/FRD-151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ