### PR TITLE
[FRD-152] Metadata on new pages

### DIFF
--- a/src/app/admin/education/[education_id]/page.tsx
+++ b/src/app/admin/education/[education_id]/page.tsx
@@ -22,7 +22,7 @@ export async function generateMetadata({ params }: { params: Promise<{ education
    };
 }
 
-export default async function EducationDetailsPage({ params }: { params: Promise<{ education_id: string }> }) {
+export default async function EducationDetailsPage() {
    const language = await headersAcceptLanguage();
 
    if (!education) {

--- a/src/app/admin/education/[education_id]/page.tsx
+++ b/src/app/admin/education/[education_id]/page.tsx
@@ -6,19 +6,33 @@ import { headersAcceptLanguage } from '@/helpers';
 import ajax from '@/hooks/useAjax';
 import { EducationData } from '@/types/database.types';
 
-export default async function EducationDetailsPage({ params }: { params: Promise<{ education_id: string }> }) {
+let education: EducationData | null = null;
+
+export async function generateMetadata({ params }: { params: Promise<{ education_id: string }> }) {
    const { education_id } = await params;
    const language = await headersAcceptLanguage();
+   const response = await ajax.get<EducationData>(`/education/${education_id}`, { params: { language_set: language } });
+   education = response.data as EducationData;
+   const languageSet = education.languageSets?.find(ls => ls.language_set === language);
+
+   return {
+      title: `${education.institution_name} (${languageSet?.field_of_study}) - Education Details`,
+      description: `Details of the education entry with ID ${education_id} - ${languageSet?.description}`,
+      language,
+   };
+}
+
+export default async function EducationDetailsPage({ params }: { params: Promise<{ education_id: string }> }) {
+   const language = await headersAcceptLanguage();
+
+   if (!education) {
+      return <ErrorContent status={404} message="Education not found" />;
+   }
 
    try {
-      const education = await ajax.get<EducationData>(`/education/${education_id}`, { params: { language_set: language } });
-      if (!education) {
-         return <ErrorContent status={404} message="Education not found" />;
-      }
-
       return (
          <AdminPageBase language={language}>
-            <EducationDetailsContent education={education.data as EducationData} />
+            <EducationDetailsContent education={education as EducationData} />
          </AdminPageBase>
       );
    } catch (error) {

--- a/src/app/admin/education/create/page.tsx
+++ b/src/app/admin/education/create/page.tsx
@@ -2,6 +2,11 @@ import { EducationCreateContent } from '@/components/content/admin/education';
 import { AdminPageBase } from '@/components/layout';
 import { headersAcceptLanguage } from '@/helpers';
 
+export const metadata = {
+   title: 'Create Education',
+   description: 'Create a new education entry',
+};
+
 export default async function EducationCreatePage() {
    const language = await headersAcceptLanguage();
 

--- a/src/app/admin/language/create/page.tsx
+++ b/src/app/admin/language/create/page.tsx
@@ -2,6 +2,11 @@ import { LanguageCreateContent } from '@/components/content/admin/language';
 import { AdminPageBase } from '@/components/layout';
 import { headersAcceptLanguage } from '@/helpers';
 
+export const metadata = {
+   title: 'Create Language',
+   description: 'Create a new language entry',
+};
+
 export default async function LanguageCreatePage() {
    const locale = await headersAcceptLanguage();
 

--- a/src/components/content/admin/education/EducationDetailsContent/subcomponents/EducationDetailsSets.tsx
+++ b/src/components/content/admin/education/EducationDetailsContent/subcomponents/EducationDetailsSets.tsx
@@ -62,7 +62,7 @@ export default function EducationDetailsSets({ cardProps }: EducationDetailsSubc
                         <label>{textResources.getText('EducationDetailsSet.fields.grade.label')}</label>
                         <p>{languageSet.grade || EMPTY_FALLBACK}</p>
                      </DataContainer>
-                     <DataContainer>
+                     <DataContainer vertical>
                         <label>{textResources.getText('EducationDetailsSet.fields.description.label')}</label>
                         <Markdown value={languageSet.description || EMPTY_FALLBACK} />
                      </DataContainer>


### PR DESCRIPTION
## [FRD-152] Description
This pull request introduces improvements to the admin education and language pages, focusing on enhanced metadata generation for detail and create pages, as well as a minor UI update for the education details component. The most significant changes include the addition of dynamic metadata generation for detail pages, static metadata for create pages, and a UI fix for displaying descriptions.

**Metadata and Data Fetching Improvements:**

* Added a `generateMetadata` function to both `EducationDetailsPage` and `LanguageDetailsPage` to dynamically generate metadata (title, description, language) based on fetched data and the current locale. Data fetching was moved out of the component and into the metadata function, improving SEO and page metadata accuracy. (`src/app/admin/education/[education_id]/page.tsx`, `src/app/admin/language/[language_id]/page.tsx`) ([src/app/admin/education/[education_id]/page.tsxL9-R35](diffhunk://#diff-5c8a8589920f85c89485e6700b1e8c9ed82bbb6dea806933a9a525a28c1ff7c8L9-R35), [src/app/admin/language/[language_id]/page.tsxL9-L27](diffhunk://#diff-7b03ac4c98ae90a35c5d00f9f80ce97c3dfc20b1f9fe90bd1cbf8881ff39c82fL9-L27))

* Added static `metadata` objects to the education and language create pages to provide consistent metadata for these routes. (`src/app/admin/education/create/page.tsx`, `src/app/admin/language/create/page.tsx`) [[1]](diffhunk://#diff-7b9d2768732b50c6386b314265b88753eb18a69b69f8adaf527757bcca49575eR5-R9) [[2]](diffhunk://#diff-307f661d937d3dfc31073ea830a1b7ce5dc2658cdc9c92aba5f74fdc55ad048eR5-R9)

**UI Improvements:**

* Updated the `EducationDetailsSets` subcomponent to use a vertical layout for the description field, ensuring better readability and alignment in the UI. (`src/components/content/admin/education/EducationDetailsContent/subcomponents/EducationDetailsSets.tsx`)

[FRD-152]: https://feliperamosdev.atlassian.net/browse/FRD-152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ