### PR TITLE
[FRD-157] Sort experiences by end_date

### DIFF
--- a/src/components/content/HomeContent/sections/Experience/Experience.tsx
+++ b/src/components/content/HomeContent/sections/Experience/Experience.tsx
@@ -9,6 +9,13 @@ import { ExperienceData } from '@/types/database.types';
 
 export default function Experience({ experiences = [] }: ExperienceProps) {
    const { textResources } = useTextResources(experienceText);
+   const sortedExperiences = experiences?.sort((a, b) => {
+      if (a.end_date && b.end_date) {
+         return a.end_date < b.end_date ? 1 : -1;
+      }
+
+      return 0;
+   });
 
    return (
       <section className="Experience" data-testid="experience-section">
@@ -18,7 +25,7 @@ export default function Experience({ experiences = [] }: ExperienceProps) {
          </div>
 
          <Container padding="xl">
-            {experiences.map((experience: ExperienceData, idx: number) => (
+            {sortedExperiences?.map((experience: ExperienceData, idx: number) => (
                <ExperienceItem
                   key={experience.id || idx}
                   experience={experience}

--- a/src/components/content/admin/curriculum/CVDetailsContent/subcomponents/CVDetailsSidebar.tsx
+++ b/src/components/content/admin/curriculum/CVDetailsContent/subcomponents/CVDetailsSidebar.tsx
@@ -115,7 +115,7 @@ export default function CVDetailsSidebar({ cardProps }: CVDetailsSubcomponentPro
             {editMode && <EditCVSkillsForm />}
             {!editMode && <div className="skills-list">
                {cv_skills.length > 0 && cv_skills.map((skill) => (
-                  <SkillBadge key={skill.id} value={skill.name} />
+                  <SkillBadge key={skill.id} value={skill.name} href={`/admin/skill/${skill.id}`} />
                ))}
             </div>}
          </Card>

--- a/src/components/content/admin/curriculum/CVDetailsContent/subcomponents/CVEducations.tsx
+++ b/src/components/content/admin/curriculum/CVDetailsContent/subcomponents/CVEducations.tsx
@@ -12,7 +12,13 @@ import { EditCVEducationsForm } from '@/components/forms/curriculums';
 export default function CVEducations({ cardProps }: CVDetailsSubcomponentProps) {
    const [ editMode, setEditMode ] = useState<boolean>(false);
    const cv = useCVDetails();
-   const educations = cv?.cv_educations || [];
+   const educations = cv?.cv_educations?.sort((a, b) => {
+      if (a.end_date && b.end_date) {
+         return a.end_date < b.end_date ? 1 : -1;
+      }
+
+      return 0;
+   }) || [];
 
    return (
       <Card className={styles.CVEducations} {...cardProps}>

--- a/src/components/content/admin/curriculum/CVDetailsContent/subcomponents/CVExperiences.tsx
+++ b/src/components/content/admin/curriculum/CVDetailsContent/subcomponents/CVExperiences.tsx
@@ -14,7 +14,13 @@ export default function CVExperiences({ cardProps }: CVDetailsSubcomponentProps)
    const [editMode, setEditMode] = useState<boolean>(false);
    const curriculum = useCVDetails();
    const { textResources } = useTextResources(texts);
-   const cv_experiences = curriculum?.cv_experiences || [];
+   const cv_experiences = curriculum?.cv_experiences?.sort((a, b) => {
+      if (a.end_date && b.end_date) {
+         return a.end_date < b.end_date ? 1 : -1;
+      }
+
+      return 0;
+   }) || [];
 
    if (!curriculum) {
       return null;

--- a/src/components/content/curriculum/CVPDFTemplateContent/sections/CVPDFEducation.tsx
+++ b/src/components/content/curriculum/CVPDFTemplateContent/sections/CVPDFEducation.tsx
@@ -6,7 +6,13 @@ import { useCVPDFTemplate } from '../CVPDFTemplateContext';
 export default function CVPDFEducation() {
    const { textResources } = useTextResources();
    const cv = useCVPDFTemplate();
-   const educations = cv.cv_educations || [];
+   const educations = cv.cv_educations?.sort((a, b) => {
+      if (a.end_date && b.end_date) {
+         return a.end_date < b.end_date ? 1 : -1;
+      }
+
+      return 0;
+   }) || [];
 
    return (
       <section className={styles.CVPDFEducation}>

--- a/src/components/content/curriculum/CVPDFTemplateContent/sections/CVPDFExperience.tsx
+++ b/src/components/content/curriculum/CVPDFTemplateContent/sections/CVPDFExperience.tsx
@@ -14,6 +14,13 @@ import { ExperienceData } from '@/types/database.types';
 export default function CVPDFExperiences(): React.ReactElement {
    const cv = useCVPDFTemplate();
    const { textResources } = useTextResources(texts);
+   const experiences = cv.cv_experiences?.sort((a, b) => {
+      if (a.end_date && b.end_date) {
+         return a.end_date < b.end_date ? 1 : -1;
+      }
+
+      return 0;
+   }) || [];
 
    const CSS = parseCSS('CVPDFExperiences', styles.CVPDFExperiences);
    const cardProps: CardProps = { elevation: 'none', padding: 'm' };
@@ -36,9 +43,9 @@ export default function CVPDFExperiences(): React.ReactElement {
             <h2>{textResources.getText('CVPDFExperiences.experiences.title')}</h2>
             <hr />
 
-            {cv.cv_experiences?.length ? (
+            {experiences?.length ? (
                <ul>
-                  {cv.cv_experiences.map((experience, index) => (
+                  {experiences.map((experience, index) => (
                      <li key={index} className={styles.experienceItem}>
                         <Card className={styles.experienceHeader} {...cardProps}>
                            <h3>{experienceTitle(experience)}</h3>

--- a/src/components/tiles/CVTile/CVTile.module.scss
+++ b/src/components/tiles/CVTile/CVTile.module.scss
@@ -4,6 +4,8 @@
    cursor: pointer;
    transition: all 100ms;
    border-bottom: 3px solid $primary;
+   -webkit-user-select: none;
+   user-select: none;
 
    &:hover {
       background-color: $background-light;

--- a/src/components/tiles/EducationTile/EducationTile.module.scss
+++ b/src/components/tiles/EducationTile/EducationTile.module.scss
@@ -7,6 +7,10 @@
    -webkit-user-select: none;
    user-select: none;
 
+   &:hover {
+      background-color: $background-light;
+   }
+
    .tileTitle {
       font-size: 0.95rem;
       font-weight: 600;

--- a/src/components/tiles/ExperienceTile/ExperienceTile.module.scss
+++ b/src/components/tiles/ExperienceTile/ExperienceTile.module.scss
@@ -6,6 +6,13 @@
    display: flex;
    flex-direction: column;
    gap: 1rem;
+   cursor: pointer;
+   -webkit-user-select: none;
+   user-select: none;
+
+   &:hover {
+      background-color: $background-light;
+   }
 
    .tileHeader {
       display: flex;

--- a/src/components/tiles/ExperienceTile/ExperienceTile.test.tsx
+++ b/src/components/tiles/ExperienceTile/ExperienceTile.test.tsx
@@ -1,7 +1,22 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import ExperienceTile from './ExperienceTile';
 import { ExperienceData } from '@/types/database.types';
 import React from 'react';
+
+// Mock router for testing navigation
+const mockPush = jest.fn();
+
+// Mock Next.js router first
+jest.mock('next/navigation', () => ({
+   useRouter: () => ({
+      push: mockPush,
+      replace: jest.fn(),
+      prefetch: jest.fn(),
+      back: jest.fn(),
+      forward: jest.fn(),
+      refresh: jest.fn(),
+   }),
+}));
 
 // Mock dayjs first
 jest.mock('dayjs', () => {
@@ -36,11 +51,17 @@ jest.mock('dayjs', () => {
 
 // Mock the Card and DateView components
 jest.mock('@/components/common', () => ({
-   Card: ({ children, className, elevation }: { children: React.ReactNode; className?: string; elevation?: number }) => (
+   Card: ({ children, className, elevation, onClick }: { 
+      children: React.ReactNode; 
+      className?: string; 
+      elevation?: string; 
+      onClick?: () => void;
+   }) => (
       <div
          data-testid="card"
          className={className}
          data-elevation={elevation}
+         onClick={onClick}
       >
          {children}
       </div>
@@ -118,6 +139,10 @@ const mockExperienceData: ExperienceData = {
 };
 
 describe('ExperienceTile', () => {
+   beforeEach(() => {
+      jest.clearAllMocks();
+   });
+
    it('renders experience tile with all content', () => {
       render(<ExperienceTile experience={mockExperienceData} />);
 
@@ -228,5 +253,14 @@ describe('ExperienceTile', () => {
       expect(dateViews).toHaveLength(2);
       expect(dateViews[0]).toHaveTextContent('---');
       expect(dateViews[1]).toHaveTextContent('---');
+   });
+
+   it('navigates to experience detail page when clicked', () => {
+      render(<ExperienceTile experience={mockExperienceData} />);
+
+      const card = screen.getByTestId('card');
+      fireEvent.click(card);
+
+      expect(mockPush).toHaveBeenCalledWith('/admin/experience/1');
    });
 });

--- a/src/components/tiles/ExperienceTile/ExperienceTile.tsx
+++ b/src/components/tiles/ExperienceTile/ExperienceTile.tsx
@@ -3,8 +3,11 @@ import { ExperienceTileProps } from './ExperienceTile.types';
 import styles from './ExperienceTile.module.scss';
 import { Card, DateView } from '@/components/common';
 import { Avatar } from '@mui/material';
+import { useRouter } from 'next/navigation';
 
 export default function ExperienceTile({ className, experience }: ExperienceTileProps): React.ReactElement {
+   const router = useRouter();
+
    const CSS = parseCSS(className, [
       'ExperienceTile',
       styles.ExperienceTile
@@ -15,7 +18,7 @@ export default function ExperienceTile({ className, experience }: ExperienceTile
    }
 
    return (
-      <Card className={CSS} elevation="none">
+      <Card className={CSS} elevation="none" onClick={() => router.push(`/admin/experience/${experience.id}`)}>
          <div className={styles.tileHeader}>
             <div className={styles.companyLogo}>
                <Avatar className={styles.avatar} src={experience.company?.logo_url} alt={experience.company?.company_name} />

--- a/src/components/tiles/LanguageTile/LanguageTile.module.scss
+++ b/src/components/tiles/LanguageTile/LanguageTile.module.scss
@@ -8,6 +8,10 @@
    -webkit-user-select: none;
    user-select: none;
 
+   &:hover {
+      background-color: $background-light;
+   }
+
    &:not(:last-child) {
       margin-bottom: 0.5rem;
    }


### PR DESCRIPTION
## [FRD-157] Description
This pull request introduces several improvements to how experiences and educations are displayed and interacted with in the application. The main changes include sorting experiences and educations by end date (most recent first) in both the user-facing and admin interfaces, making experience and education tiles more interactive and visually responsive, and enhancing navigation and linking within the admin UI.

**Data Sorting Improvements:**

* Experiences and educations are now sorted by `end_date` in descending order (most recent first) across the following components: `Experience`, `CVExperiences`, `CVEducations`, `CVPDFExperiences`, and `CVPDFEducation`. This ensures a consistent and logical display order throughout the application. [[1]](diffhunk://#diff-6ecd09682cdc49fa547e6628b606089520fae639379e635f99c715bdc68a5c3bR12-R18) [[2]](diffhunk://#diff-6ecd09682cdc49fa547e6628b606089520fae639379e635f99c715bdc68a5c3bL21-R28) [[3]](diffhunk://#diff-ca09c13ff6240076707a3db8eb99bcbd4c237e300ee2e0906dfbec732eeb77b7L17-R23) [[4]](diffhunk://#diff-2a09442868b5ee3233fa2dd718a99e01246f9d2ecaccf4abee49fcc460fcc75bL15-R21) [[5]](diffhunk://#diff-5cf965b2af3e3be563e273432ac2c3e129751eab9cc1f4f75899d12e5e64be68R17-R23) [[6]](diffhunk://#diff-5cf965b2af3e3be563e273432ac2c3e129751eab9cc1f4f75899d12e5e64be68L39-R48) [[7]](diffhunk://#diff-3a430ee0f9d9678a515204f75f066817aee19ed50aafa32fe6507e499022493fL9-R15)

**UI Interactivity and Styling:**

* Added `cursor: pointer`, disabled text selection, and hover background color effects to `CVTile`, `ExperienceTile`, `EducationTile`, and `LanguageTile` components, making them feel more interactive and visually responsive. [[1]](diffhunk://#diff-37081d588ad9707ed5dcf5cd14b45f350379105a7db9e61ca524c52e2e8d48d3R7-R8) [[2]](diffhunk://#diff-800ad31200e38af23da308176b5b75697a1e7baae71ed0dc5a61b690dfe86936R9-R15) [[3]](diffhunk://#diff-1a62debcd21e1f2ecc5aae80e51a879859983fa5669bc4eb2cc82bb7d166ba2bR10-R13) [[4]](diffhunk://#diff-ed5812817525dda02bae20b5160131218cb222d38c1c671e316ce569876ba160R11-R14)

**Navigation and Linking Enhancements:**

* Made `ExperienceTile` components clickable, navigating to the corresponding admin experience detail page on click. [[1]](diffhunk://#diff-edc0f5e34936b642dd923511d96b16fceaee53f7b8572b4f77d50e3cd123ee13R6-R10) [[2]](diffhunk://#diff-edc0f5e34936b642dd923511d96b16fceaee53f7b8572b4f77d50e3cd123ee13L18-R21)
* Updated `SkillBadge` components in the CV details sidebar to link to their respective admin skill detail pages, improving navigation for admins.

[FRD-157]: https://feliperamosdev.atlassian.net/browse/FRD-157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ