### PR TITLE
[FRD-161] Hide empty content blocks and remove titles

### DIFF
--- a/src/components/content/curriculum/CVPDFTemplateContent/CVPDFTemplateContent.module.scss
+++ b/src/components/content/curriculum/CVPDFTemplateContent/CVPDFTemplateContent.module.scss
@@ -71,7 +71,7 @@
          li {
             font-size: 0.9rem;
             list-style: disc;
-            margin-bottom: 0.5rem;
+            margin-bottom: 0.4rem;
             line-height: 1.3rem;
          }
       }

--- a/src/components/content/curriculum/CVPDFTemplateContent/sections/CVPDFExperience.tsx
+++ b/src/components/content/curriculum/CVPDFTemplateContent/sections/CVPDFExperience.tsx
@@ -87,15 +87,23 @@ export default function CVPDFExperiences(): React.ReactElement {
 
                         <Card className={styles.experienceDetails} {...cardProps}>
                            <ContentSidebar breakpoint="m">
-                              <Fragment>
-                                 <h4>{textResources.getText('CVPDFExperiences.experiences.description')}</h4>
-                                 <Markdown className={styles.markdown} value={experience.summary} />
-                                 <Markdown className={styles.markdown} value={experience.description} />
-                              </Fragment>
-                              <Fragment>
-                                 <h4>{textResources.getText('CVPDFExperiences.experiences.responsibilities')}</h4>
-                                 <Markdown className={styles.markdown} value={experience.responsibilities} />
-                              </Fragment>
+                              {(experience.summary || experience.description) && (
+                                 <Fragment>
+                                    {experience.summary && (
+                                       <Markdown className={styles.markdown} value={experience.summary} />
+                                    )}
+
+                                    {experience.description && (
+                                       <Markdown className={styles.markdown} value={experience.description} />
+                                    )}
+                                 </Fragment>
+                              )}
+
+                              {experience.responsibilities && (
+                                 <Fragment>
+                                    <Markdown className={styles.markdown} value={experience.responsibilities} />
+                                 </Fragment>
+                              )}
                            </ContentSidebar>
                         </Card>
                      </li>

--- a/src/components/layout/ContentSidebar/ContentSidebar.tsx
+++ b/src/components/layout/ContentSidebar/ContentSidebar.tsx
@@ -32,9 +32,11 @@ export default function ContentSidebar({
             {childrenArray[0] || null}
          </article>
 
-         <aside className="sidebar">
-            {childrenArray[1] || null}
-         </aside>
+         {childrenArray[1] && (
+            <aside className="sidebar">
+               {childrenArray[1] || null}
+            </aside>
+         )}
       </div>
    );
 }


### PR DESCRIPTION
## [FRD-161] Description
This pull request makes improvements to the rendering logic and styling of the CV PDF experience section. The main changes focus on conditional rendering of content blocks to ensure that only relevant sections are displayed, and a minor adjustment to list item spacing for better visual consistency.

**Rendering logic improvements:**

* In `CVPDFExperience.tsx`, the summary and description sections are now only rendered if they exist, preventing empty headings or blocks. Similarly, the responsibilities section is only shown if present.
* In `ContentSidebar.tsx`, the sidebar is now conditionally rendered only if there is content for it, avoiding unnecessary empty sidebar elements.

**Styling adjustment:**

* In `CVPDFTemplateContent.module.scss`, the bottom margin for list items within experiences is slightly reduced from 0.5rem to 0.4rem for improved spacing.