### PR TITLE
[FRD-165] Render chat messages from markdown

### DIFF
--- a/__mocks__/marked.js
+++ b/__mocks__/marked.js
@@ -1,9 +1,11 @@
 // Mock for marked module
-export const marked = {
-  parse: (markdown) => `<p>${markdown}</p>`,
-  setOptions: () => {},
-  use: () => {},
-  defaults: {},
-};
+const marked = jest.fn((markdown) => `<p>${markdown}</p>`);
 
+// Add properties to mimic the real marked object
+marked.parse = jest.fn((markdown) => `<p>${markdown}</p>`);
+marked.setOptions = jest.fn(() => {});
+marked.use = jest.fn(() => {});
+marked.defaults = {};
+
+export { marked };
 export default marked;

--- a/src/components/chat/ChatMessage/ChatMessage.scss
+++ b/src/components/chat/ChatMessage/ChatMessage.scss
@@ -10,6 +10,7 @@
       .message-container {
          .content {
             text-align: left;
+            margin-bottom: 0;
          }
 
          .message-date {
@@ -27,7 +28,6 @@
       padding: $padding-s;
       border-radius: $radius-s;
       text-align: left;
-      white-space: pre-line;
       box-shadow: 0 0 20px $black;
 
       .message-date {

--- a/src/components/chat/ChatMessage/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage/ChatMessage.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Card from '@/components/common/Card/Card';
 import { ChatMessageProps } from '../Chat/Chat.types';
+import { Markdown } from '@/components/common';
 
 const ChatMessage: React.FC<ChatMessageProps> = ({ index, message, ...props }) => {
    const isSelfClass: string = message.self ? 'is-self' : '';
@@ -18,9 +19,7 @@ const ChatMessage: React.FC<ChatMessageProps> = ({ index, message, ...props }) =
          {...props}
       >
          <div className="message-container">
-            <div className="content">
-               {message.content}
-            </div>
+            <Markdown className="content" value={message.content} />
 
             {message.timestamp &&<div className="message-date">
                <small className="date" data-testid={`message-date-${index}`}>{message.dateString}</small>{' - '}

--- a/src/components/common/Markdown/Markdown.module.scss
+++ b/src/components/common/Markdown/Markdown.module.scss
@@ -17,7 +17,8 @@
       margin-bottom: 0.5rem;
    }
 
-   ul {
+   ul,
+   ol {
       li {
          margin-bottom: 0.5rem;
          margin-left: 1.4rem;


### PR DESCRIPTION
## [FRD-165] Description
This pull request updates the chat message rendering to use a Markdown component, improving message formatting and consistency. It also includes minor style adjustments to both the chat message and Markdown components.

**Chat message rendering improvements:**
* Replaced plain text rendering of message content in `ChatMessage` with the `Markdown` component for better formatting and support for markdown syntax. [[1]](diffhunk://#diff-7bf2e29338fc1eb2a89296d2d8f995a8513f0a485f63638dbae9f719ec881e68R4) [[2]](diffhunk://#diff-7bf2e29338fc1eb2a89296d2d8f995a8513f0a485f63638dbae9f719ec881e68L21-R22)

**Style adjustments:**
* Added `margin-bottom: 0` to the `.content` class and removed `white-space: pre-line` from `.message` in `ChatMessage.scss` to refine message spacing and text formatting. [[1]](diffhunk://#diff-ff3140bdff1a53e3f8bab02b9b6de78a15777d06785a9d43d3e485659152aab0R13) [[2]](diffhunk://#diff-ff3140bdff1a53e3f8bab02b9b6de78a15777d06785a9d43d3e485659152aab0L30)
* Updated `Markdown.module.scss` to apply consistent list item spacing to both unordered (`ul`) and ordered (`ol`) lists.

[FRD-165]: https://feliperamosdev.atlassian.net/browse/FRD-165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ