### PR TITLE
[FRD-156] Small Issues and Adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Felipe Ramos - Interactive Resume & Portfolio (v1.4.0)
+# Felipe Ramos - Interactive Resume & Portfolio (v1.4.1)
 
 A modern, AI-powered interactive resume built with Next.js, featuring real-time chat capabilities and a sleek user interface. This project serves as both a portfolio showcase and an intelligent assistant that can answer questions about Felipe's professional background.
 

--- a/__mocks__/marked.js
+++ b/__mocks__/marked.js
@@ -1,9 +1,11 @@
 // Mock for marked module
-export const marked = {
-  parse: (markdown) => `<p>${markdown}</p>`,
-  setOptions: () => {},
-  use: () => {},
-  defaults: {},
-};
+const marked = jest.fn((markdown) => `<p>${markdown}</p>`);
 
+// Add properties to mimic the real marked object
+marked.parse = jest.fn((markdown) => `<p>${markdown}</p>`);
+marked.setOptions = jest.fn(() => {});
+marked.use = jest.fn(() => {});
+marked.defaults = {};
+
+export { marked };
 export default marked;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feliperamos-dev",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/components/chat/ChatMessage/ChatMessage.scss
+++ b/src/components/chat/ChatMessage/ChatMessage.scss
@@ -10,6 +10,7 @@
       .message-container {
          .content {
             text-align: left;
+            margin-bottom: 0;
          }
 
          .message-date {
@@ -27,7 +28,6 @@
       padding: $padding-s;
       border-radius: $radius-s;
       text-align: left;
-      white-space: pre-line;
       box-shadow: 0 0 20px $black;
 
       .message-date {

--- a/src/components/chat/ChatMessage/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage/ChatMessage.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Card from '@/components/common/Card/Card';
 import { ChatMessageProps } from '../Chat/Chat.types';
+import { Markdown } from '@/components/common';
 
 const ChatMessage: React.FC<ChatMessageProps> = ({ index, message, ...props }) => {
    const isSelfClass: string = message.self ? 'is-self' : '';
@@ -18,9 +19,7 @@ const ChatMessage: React.FC<ChatMessageProps> = ({ index, message, ...props }) =
          {...props}
       >
          <div className="message-container">
-            <div className="content">
-               {message.content}
-            </div>
+            <Markdown className="content" value={message.content} />
 
             {message.timestamp &&<div className="message-date">
                <small className="date" data-testid={`message-date-${index}`}>{message.dateString}</small>{' - '}

--- a/src/components/common/Markdown/Markdown.module.scss
+++ b/src/components/common/Markdown/Markdown.module.scss
@@ -17,7 +17,8 @@
       margin-bottom: 0.5rem;
    }
 
-   ul {
+   ul,
+   ol {
       li {
          margin-bottom: 0.5rem;
          margin-left: 1.4rem;

--- a/src/components/content/HomeContent/sections/Experience/Experience.tsx
+++ b/src/components/content/HomeContent/sections/Experience/Experience.tsx
@@ -9,6 +9,13 @@ import { ExperienceData } from '@/types/database.types';
 
 export default function Experience({ experiences = [] }: ExperienceProps) {
    const { textResources } = useTextResources(experienceText);
+   const sortedExperiences = experiences?.sort((a, b) => {
+      if (a.end_date && b.end_date) {
+         return a.end_date < b.end_date ? 1 : -1;
+      }
+
+      return 0;
+   });
 
    return (
       <section className="Experience" data-testid="experience-section">
@@ -18,7 +25,7 @@ export default function Experience({ experiences = [] }: ExperienceProps) {
          </div>
 
          <Container padding="xl">
-            {experiences.map((experience: ExperienceData, idx: number) => (
+            {sortedExperiences?.map((experience: ExperienceData, idx: number) => (
                <ExperienceItem
                   key={experience.id || idx}
                   experience={experience}

--- a/src/components/content/admin/curriculum/CVDetailsContent/CVDetailsContent.module.scss
+++ b/src/components/content/admin/curriculum/CVDetailsContent/CVDetailsContent.module.scss
@@ -10,6 +10,12 @@
    }
 }
 
+.skillsList {
+   a {
+      margin-bottom: 0.5rem;
+   }
+}
+
 .pdfDownload {
    width: 100%;
    display: flex;

--- a/src/components/content/admin/curriculum/CVDetailsContent/subcomponents/CVDetailsSidebar.tsx
+++ b/src/components/content/admin/curriculum/CVDetailsContent/subcomponents/CVDetailsSidebar.tsx
@@ -113,7 +113,7 @@ export default function CVDetailsSidebar({ cardProps }: CVDetailsSubcomponentPro
             </WidgetHeader>
 
             {editMode && <EditCVSkillsForm />}
-            {!editMode && <div className="skills-list">
+            {!editMode && <div className={styles.skillsList}>
                {cv_skills.length > 0 && cv_skills.map((skill) => (
                   <SkillBadge key={skill.id} value={skill.name} href={`/admin/skill/${skill.id}`} />
                ))}

--- a/src/components/content/admin/curriculum/CVDetailsContent/subcomponents/CVDetailsSidebar.tsx
+++ b/src/components/content/admin/curriculum/CVDetailsContent/subcomponents/CVDetailsSidebar.tsx
@@ -115,7 +115,7 @@ export default function CVDetailsSidebar({ cardProps }: CVDetailsSubcomponentPro
             {editMode && <EditCVSkillsForm />}
             {!editMode && <div className="skills-list">
                {cv_skills.length > 0 && cv_skills.map((skill) => (
-                  <SkillBadge key={skill.id} value={skill.name} />
+                  <SkillBadge key={skill.id} value={skill.name} href={`/admin/skill/${skill.id}`} />
                ))}
             </div>}
          </Card>

--- a/src/components/content/admin/curriculum/CVDetailsContent/subcomponents/CVEducations.tsx
+++ b/src/components/content/admin/curriculum/CVDetailsContent/subcomponents/CVEducations.tsx
@@ -12,7 +12,13 @@ import { EditCVEducationsForm } from '@/components/forms/curriculums';
 export default function CVEducations({ cardProps }: CVDetailsSubcomponentProps) {
    const [ editMode, setEditMode ] = useState<boolean>(false);
    const cv = useCVDetails();
-   const educations = cv?.cv_educations || [];
+   const educations = cv?.cv_educations?.sort((a, b) => {
+      if (a.end_date && b.end_date) {
+         return a.end_date < b.end_date ? 1 : -1;
+      }
+
+      return 0;
+   }) || [];
 
    return (
       <Card className={styles.CVEducations} {...cardProps}>

--- a/src/components/content/admin/curriculum/CVDetailsContent/subcomponents/CVExperiences.tsx
+++ b/src/components/content/admin/curriculum/CVDetailsContent/subcomponents/CVExperiences.tsx
@@ -14,7 +14,13 @@ export default function CVExperiences({ cardProps }: CVDetailsSubcomponentProps)
    const [editMode, setEditMode] = useState<boolean>(false);
    const curriculum = useCVDetails();
    const { textResources } = useTextResources(texts);
-   const cv_experiences = curriculum?.cv_experiences || [];
+   const cv_experiences = curriculum?.cv_experiences?.sort((a, b) => {
+      if (a.end_date && b.end_date) {
+         return a.end_date < b.end_date ? 1 : -1;
+      }
+
+      return 0;
+   }) || [];
 
    if (!curriculum) {
       return null;

--- a/src/components/content/curriculum/CVPDFTemplateContent/CVPDFTemplateContent.module.scss
+++ b/src/components/content/curriculum/CVPDFTemplateContent/CVPDFTemplateContent.module.scss
@@ -71,7 +71,7 @@
          li {
             font-size: 0.9rem;
             list-style: disc;
-            margin-bottom: 0.5rem;
+            margin-bottom: 0.4rem;
             line-height: 1.3rem;
          }
       }

--- a/src/components/content/curriculum/CVPDFTemplateContent/sections/CVPDFEducation.tsx
+++ b/src/components/content/curriculum/CVPDFTemplateContent/sections/CVPDFEducation.tsx
@@ -6,7 +6,13 @@ import { useCVPDFTemplate } from '../CVPDFTemplateContext';
 export default function CVPDFEducation() {
    const { textResources } = useTextResources();
    const cv = useCVPDFTemplate();
-   const educations = cv.cv_educations || [];
+   const educations = cv.cv_educations?.sort((a, b) => {
+      if (a.end_date && b.end_date) {
+         return a.end_date < b.end_date ? 1 : -1;
+      }
+
+      return 0;
+   }) || [];
 
    return (
       <section className={styles.CVPDFEducation}>

--- a/src/components/content/curriculum/CVPDFTemplateContent/sections/CVPDFEducation.tsx
+++ b/src/components/content/curriculum/CVPDFTemplateContent/sections/CVPDFEducation.tsx
@@ -2,6 +2,7 @@ import { Container, DateView, Markdown } from '@/components/common';
 import styles from '../CVPDFTemplateContent.module.scss';
 import { useTextResources } from '@/services/TextResources/TextResourcesProvider';
 import { useCVPDFTemplate } from '../CVPDFTemplateContext';
+import { parseCSS } from '@/helpers/parse.helpers';
 
 export default function CVPDFEducation() {
    const { textResources } = useTextResources();
@@ -28,7 +29,7 @@ export default function CVPDFEducation() {
                      <p><DateView date={education.start_date} /> - <DateView date={education.end_date} /></p>
 
                      {education.description && (
-                        <Markdown className={styles.description} value={education.description} />
+                        <Markdown className={parseCSS(styles.description, styles.markdown)} value={education.description} />
                      )}
                   </li>
                ))}

--- a/src/components/content/curriculum/CVPDFTemplateContent/sections/CVPDFExperience.tsx
+++ b/src/components/content/curriculum/CVPDFTemplateContent/sections/CVPDFExperience.tsx
@@ -87,15 +87,23 @@ export default function CVPDFExperiences(): React.ReactElement {
 
                         <Card className={styles.experienceDetails} {...cardProps}>
                            <ContentSidebar breakpoint="m">
-                              <Fragment>
-                                 <h4>{textResources.getText('CVPDFExperiences.experiences.description')}</h4>
-                                 <Markdown className={styles.markdown} value={experience.summary} />
-                                 <Markdown className={styles.markdown} value={experience.description} />
-                              </Fragment>
-                              <Fragment>
-                                 <h4>{textResources.getText('CVPDFExperiences.experiences.responsibilities')}</h4>
-                                 <Markdown className={styles.markdown} value={experience.responsibilities} />
-                              </Fragment>
+                              {(experience.summary || experience.description) && (
+                                 <Fragment>
+                                    {experience.summary && (
+                                       <Markdown className={styles.markdown} value={experience.summary} />
+                                    )}
+
+                                    {experience.description && (
+                                       <Markdown className={styles.markdown} value={experience.description} />
+                                    )}
+                                 </Fragment>
+                              )}
+
+                              {experience.responsibilities && (
+                                 <Fragment>
+                                    <Markdown className={styles.markdown} value={experience.responsibilities} />
+                                 </Fragment>
+                              )}
                            </ContentSidebar>
                         </Card>
                      </li>

--- a/src/components/content/curriculum/CVPDFTemplateContent/sections/CVPDFExperience.tsx
+++ b/src/components/content/curriculum/CVPDFTemplateContent/sections/CVPDFExperience.tsx
@@ -14,6 +14,13 @@ import { ExperienceData } from '@/types/database.types';
 export default function CVPDFExperiences(): React.ReactElement {
    const cv = useCVPDFTemplate();
    const { textResources } = useTextResources(texts);
+   const experiences = cv.cv_experiences?.sort((a, b) => {
+      if (a.end_date && b.end_date) {
+         return a.end_date < b.end_date ? 1 : -1;
+      }
+
+      return 0;
+   }) || [];
 
    const CSS = parseCSS('CVPDFExperiences', styles.CVPDFExperiences);
    const cardProps: CardProps = { elevation: 'none', padding: 'm' };
@@ -36,9 +43,9 @@ export default function CVPDFExperiences(): React.ReactElement {
             <h2>{textResources.getText('CVPDFExperiences.experiences.title')}</h2>
             <hr />
 
-            {cv.cv_experiences?.length ? (
+            {experiences?.length ? (
                <ul>
-                  {cv.cv_experiences.map((experience, index) => (
+                  {experiences.map((experience, index) => (
                      <li key={index} className={styles.experienceItem}>
                         <Card className={styles.experienceHeader} {...cardProps}>
                            <h3>{experienceTitle(experience)}</h3>

--- a/src/components/content/curriculum/CVPDFTemplateContent/sections/CVPDFLanguages.tsx
+++ b/src/components/content/curriculum/CVPDFTemplateContent/sections/CVPDFLanguages.tsx
@@ -20,7 +20,6 @@ export default function CVPDFLanguages() {
                   <li key={language.id} className={styles.languageItem}>
                      <p className={styles.languageTitle}>{language.default_name}</p>
                      <p className={styles.languageProficiency}>
-                        <span>{textResources.getText('CVPDFLanguages.proficiency')}</span>
                         {displayProficiency(language.proficiency, textResources.currentLanguage)}
                      </p>
                   </li>

--- a/src/components/content/curriculum/CVPDFTemplateContent/sections/CVPDFSummary.tsx
+++ b/src/components/content/curriculum/CVPDFTemplateContent/sections/CVPDFSummary.tsx
@@ -17,7 +17,7 @@ export default function CVPDFSummary(): React.ReactElement {
             <hr />
 
             <Markdown
-               className={styles.summary}
+               className={parseCSS(styles.summary, styles.markdown)}
                value={cv.summary}
             />
          </Container>

--- a/src/components/layout/ContentSidebar/ContentSidebar.test.tsx
+++ b/src/components/layout/ContentSidebar/ContentSidebar.test.tsx
@@ -47,17 +47,17 @@ describe('ContentSidebar', () => {
          expect(result.type).toBe('div');
       });
 
-      it('renders content and sidebar divs', () => {
+      it('renders content div only when no children provided', () => {
          render(<ContentSidebar />);
 
          const content = document.querySelector('.content');
          const sidebar = document.querySelector('.sidebar');
 
          expect(content).toBeInTheDocument();
-         expect(sidebar).toBeInTheDocument();
+         expect(sidebar).not.toBeInTheDocument();
       });
 
-      it('maintains proper DOM structure', () => {
+      it('maintains proper DOM structure when no children', () => {
          render(<ContentSidebar />);
 
          const container = document.querySelector('.ContentSidebar') as HTMLElement;
@@ -65,8 +65,8 @@ describe('ContentSidebar', () => {
          const sidebar = document.querySelector('.sidebar') as HTMLElement;
 
          expect(container).toContainElement(content);
-         expect(container).toContainElement(sidebar);
-         expect(container?.children).toHaveLength(2);
+         expect(sidebar).not.toBeInTheDocument();
+         expect(container?.children).toHaveLength(1);
       });
    });
 
@@ -121,7 +121,7 @@ describe('ContentSidebar', () => {
          const contentElement = screen.getByTestId('content-child');
 
          expect(content).toContainElement(contentElement);
-         expect(sidebar).toBeEmptyDOMElement();
+         expect(sidebar).not.toBeInTheDocument();
       });
 
       it('handles no children', () => {
@@ -131,7 +131,7 @@ describe('ContentSidebar', () => {
          const sidebar = document.querySelector('.sidebar');
 
          expect(content).toBeEmptyDOMElement();
-         expect(sidebar).toBeEmptyDOMElement();
+         expect(sidebar).not.toBeInTheDocument();
       });
 
       it('handles more than two children (only uses first two)', () => {
@@ -164,7 +164,7 @@ describe('ContentSidebar', () => {
          const sidebar = document.querySelector('.sidebar');
 
          expect(content).toBeEmptyDOMElement();
-         expect(sidebar).toBeEmptyDOMElement();
+         expect(sidebar).not.toBeInTheDocument();
       });
    });
 
@@ -338,7 +338,7 @@ describe('ContentSidebar', () => {
          const sidebar = document.querySelector('.sidebar');
 
          expect(content).toBeEmptyDOMElement();
-         expect(sidebar).toBeEmptyDOMElement();
+         expect(sidebar).not.toBeInTheDocument();
       });
 
       it('uses empty string as default className', () => {
@@ -360,8 +360,13 @@ describe('ContentSidebar', () => {
    });
 
    describe('Component structure', () => {
-      it('has correct HTML structure', () => {
-         render(<ContentSidebar />);
+      it('has correct HTML structure when both content and sidebar present', () => {
+         render(
+            <ContentSidebar>
+               <div>Content</div>
+               <div>Sidebar</div>
+            </ContentSidebar>
+         );
 
          const container = document.querySelector('.ContentSidebar') as HTMLElement;
          const content = document.querySelector('.content') as HTMLElement;
@@ -374,8 +379,13 @@ describe('ContentSidebar', () => {
          expect(container).toContainElement(sidebar);
       });
 
-      it('maintains proper element order', () => {
-         render(<ContentSidebar />);
+      it('maintains proper element order when both elements present', () => {
+         render(
+            <ContentSidebar>
+               <div>Content</div>
+               <div>Sidebar</div>
+            </ContentSidebar>
+         );
 
          const container = document.querySelector('.ContentSidebar');
          const children = container?.children;
@@ -385,8 +395,27 @@ describe('ContentSidebar', () => {
          expect(children?.[1]).toHaveClass('sidebar');
       });
 
-      it('applies correct CSS classes to children', () => {
-         render(<ContentSidebar />);
+      it('maintains proper element order when only content present', () => {
+         render(
+            <ContentSidebar>
+               <div>Content only</div>
+            </ContentSidebar>
+         );
+
+         const container = document.querySelector('.ContentSidebar');
+         const children = container?.children;
+
+         expect(children).toHaveLength(1);
+         expect(children?.[0]).toHaveClass('content');
+      });
+
+      it('applies correct CSS classes to children when both present', () => {
+         render(
+            <ContentSidebar>
+               <div>Content</div>
+               <div>Sidebar</div>
+            </ContentSidebar>
+         );
 
          const content = document.querySelector('.content');
          const sidebar = document.querySelector('.sidebar');
@@ -638,8 +667,13 @@ describe('ContentSidebar', () => {
    });
 
    describe('Layout behavior', () => {
-      it('supports responsive layout structure', () => {
-         render(<ContentSidebar />);
+      it('supports responsive layout structure when both elements present', () => {
+         render(
+            <ContentSidebar>
+               <div>Content</div>
+               <div>Sidebar</div>
+            </ContentSidebar>
+         );
 
          const container = document.querySelector('.ContentSidebar');
          const content = document.querySelector('.content');

--- a/src/components/layout/ContentSidebar/ContentSidebar.tsx
+++ b/src/components/layout/ContentSidebar/ContentSidebar.tsx
@@ -32,9 +32,11 @@ export default function ContentSidebar({
             {childrenArray[0] || null}
          </article>
 
-         <aside className="sidebar">
-            {childrenArray[1] || null}
-         </aside>
+         {childrenArray[1] && (
+            <aside className="sidebar">
+               {childrenArray[1] || null}
+            </aside>
+         )}
       </div>
    );
 }

--- a/src/components/tiles/CVTile/CVTile.module.scss
+++ b/src/components/tiles/CVTile/CVTile.module.scss
@@ -4,6 +4,8 @@
    cursor: pointer;
    transition: all 100ms;
    border-bottom: 3px solid $primary;
+   -webkit-user-select: none;
+   user-select: none;
 
    &:hover {
       background-color: $background-light;

--- a/src/components/tiles/EducationTile/EducationTile.module.scss
+++ b/src/components/tiles/EducationTile/EducationTile.module.scss
@@ -7,6 +7,10 @@
    -webkit-user-select: none;
    user-select: none;
 
+   &:hover {
+      background-color: $background-light;
+   }
+
    .tileTitle {
       font-size: 0.95rem;
       font-weight: 600;

--- a/src/components/tiles/ExperienceTile/ExperienceTile.module.scss
+++ b/src/components/tiles/ExperienceTile/ExperienceTile.module.scss
@@ -6,6 +6,13 @@
    display: flex;
    flex-direction: column;
    gap: 1rem;
+   cursor: pointer;
+   -webkit-user-select: none;
+   user-select: none;
+
+   &:hover {
+      background-color: $background-light;
+   }
 
    .tileHeader {
       display: flex;

--- a/src/components/tiles/ExperienceTile/ExperienceTile.test.tsx
+++ b/src/components/tiles/ExperienceTile/ExperienceTile.test.tsx
@@ -1,7 +1,22 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import ExperienceTile from './ExperienceTile';
 import { ExperienceData } from '@/types/database.types';
 import React from 'react';
+
+// Mock router for testing navigation
+const mockPush = jest.fn();
+
+// Mock Next.js router first
+jest.mock('next/navigation', () => ({
+   useRouter: () => ({
+      push: mockPush,
+      replace: jest.fn(),
+      prefetch: jest.fn(),
+      back: jest.fn(),
+      forward: jest.fn(),
+      refresh: jest.fn(),
+   }),
+}));
 
 // Mock dayjs first
 jest.mock('dayjs', () => {
@@ -36,11 +51,17 @@ jest.mock('dayjs', () => {
 
 // Mock the Card and DateView components
 jest.mock('@/components/common', () => ({
-   Card: ({ children, className, elevation }: { children: React.ReactNode; className?: string; elevation?: number }) => (
+   Card: ({ children, className, elevation, onClick }: { 
+      children: React.ReactNode; 
+      className?: string; 
+      elevation?: string; 
+      onClick?: () => void;
+   }) => (
       <div
          data-testid="card"
          className={className}
          data-elevation={elevation}
+         onClick={onClick}
       >
          {children}
       </div>
@@ -118,6 +139,10 @@ const mockExperienceData: ExperienceData = {
 };
 
 describe('ExperienceTile', () => {
+   beforeEach(() => {
+      jest.clearAllMocks();
+   });
+
    it('renders experience tile with all content', () => {
       render(<ExperienceTile experience={mockExperienceData} />);
 
@@ -228,5 +253,14 @@ describe('ExperienceTile', () => {
       expect(dateViews).toHaveLength(2);
       expect(dateViews[0]).toHaveTextContent('---');
       expect(dateViews[1]).toHaveTextContent('---');
+   });
+
+   it('navigates to experience detail page when clicked', () => {
+      render(<ExperienceTile experience={mockExperienceData} />);
+
+      const card = screen.getByTestId('card');
+      fireEvent.click(card);
+
+      expect(mockPush).toHaveBeenCalledWith('/admin/experience/1');
    });
 });

--- a/src/components/tiles/ExperienceTile/ExperienceTile.tsx
+++ b/src/components/tiles/ExperienceTile/ExperienceTile.tsx
@@ -3,8 +3,11 @@ import { ExperienceTileProps } from './ExperienceTile.types';
 import styles from './ExperienceTile.module.scss';
 import { Card, DateView } from '@/components/common';
 import { Avatar } from '@mui/material';
+import { useRouter } from 'next/navigation';
 
 export default function ExperienceTile({ className, experience }: ExperienceTileProps): React.ReactElement {
+   const router = useRouter();
+
    const CSS = parseCSS(className, [
       'ExperienceTile',
       styles.ExperienceTile
@@ -15,7 +18,7 @@ export default function ExperienceTile({ className, experience }: ExperienceTile
    }
 
    return (
-      <Card className={CSS} elevation="none">
+      <Card className={CSS} elevation="none" onClick={() => router.push(`/admin/experience/${experience.id}`)}>
          <div className={styles.tileHeader}>
             <div className={styles.companyLogo}>
                <Avatar className={styles.avatar} src={experience.company?.logo_url} alt={experience.company?.company_name} />

--- a/src/components/tiles/LanguageTile/LanguageTile.module.scss
+++ b/src/components/tiles/LanguageTile/LanguageTile.module.scss
@@ -8,6 +8,10 @@
    -webkit-user-select: none;
    user-select: none;
 
+   &:hover {
+      background-color: $background-light;
+   }
+
    &:not(:last-child) {
       margin-bottom: 0.5rem;
    }

--- a/src/components/widgets/ExperiencesWidget/experienceWidget.config.tsx
+++ b/src/components/widgets/ExperiencesWidget/experienceWidget.config.tsx
@@ -22,34 +22,17 @@ export const experienceWidgetColumns: IColumnConfig[] = [
       }
    },
    {
-      propKey: 'type',
-      label: 'Type',
+      propKey: 'title',
+      label: 'Title',
       align: 'left',
-      format: (value: unknown) => {
-         switch (value) {
-            case 'internship':
-               return 'Internship';
-            case 'freelance':
-               return 'Freelance';
-            case 'contract':
-               return 'Contract';
-            case 'temporary':
-               return 'Temporary';
-            case 'full_time':
-               return 'Full Time';
-            case 'part_time':
-               return 'Part Time';
-            case 'other':
-               return 'Other';
-            default:
-               return 'Unknown';
-         }
-      }
+      minWidth: 150,
    },
    {
       propKey: 'status',
       label: 'Skills',
       align: 'left',
+      maxWidth: 90,
+      minWidth: 90,
       format: (value: unknown) => {
          return (
             <SkillBadge value={value as string} padding="xs" />
@@ -60,7 +43,8 @@ export const experienceWidgetColumns: IColumnConfig[] = [
       propKey: 'data',
       label: 'Start Date',
       align: 'left',
-      minWidth: 230,
+      maxWidth: 120,
+      minWidth: 120,
       format: (_: unknown, item: unknown) => {
          const row = item as ExperienceData;
          return <p><DateView date={row.start_date} /> / <DateView date={row.end_date} /></p>;


### PR DESCRIPTION
## [FRD-156] Description
This pull request introduces several improvements and fixes across the portfolio and CV/resume components, focusing on sorting experiences and educations, improving markdown and chat rendering, and refining sidebar/component behaviors. The changes enhance data presentation, user experience, and code maintainability.

**Data Sorting and Presentation**

* Experiences and educations are now sorted by `end_date` in descending order across the main experience section, admin CV details, and PDF export, ensuring the most recent items are shown first. [[1]](diffhunk://#diff-6ecd09682cdc49fa547e6628b606089520fae639379e635f99c715bdc68a5c3bR12-R18) [[2]](diffhunk://#diff-6ecd09682cdc49fa547e6628b606089520fae639379e635f99c715bdc68a5c3bL21-R28) [[3]](diffhunk://#diff-2a09442868b5ee3233fa2dd718a99e01246f9d2ecaccf4abee49fcc460fcc75bL15-R21) [[4]](diffhunk://#diff-ca09c13ff6240076707a3db8eb99bcbd4c237e300ee2e0906dfbec732eeb77b7L17-R23) [[5]](diffhunk://#diff-3a430ee0f9d9678a515204f75f066817aee19ed50aafa32fe6507e499022493fR5-R16) [[6]](diffhunk://#diff-5cf965b2af3e3be563e273432ac2c3e129751eab9cc1f4f75899d12e5e64be68R17-R23)
* In the PDF export, experience details are displayed more robustly: summaries and descriptions are both shown if present, and responsibilities are only rendered when available.

**Component and UI Enhancements**

* The `ChatMessage` component now renders message content using the `Markdown` component for better formatting and consistency. [[1]](diffhunk://#diff-7bf2e29338fc1eb2a89296d2d8f995a8513f0a485f63638dbae9f719ec881e68R4) [[2]](diffhunk://#diff-7bf2e29338fc1eb2a89296d2d8f995a8513f0a485f63638dbae9f719ec881e68L21-R22)
* Minor style fixes in chat message and markdown components, such as adjusting margins and list formatting for improved appearance. [[1]](diffhunk://#diff-ff3140bdff1a53e3f8bab02b9b6de78a15777d06785a9d43d3e485659152aab0R13) [[2]](diffhunk://#diff-ff3140bdff1a53e3f8bab02b9b6de78a15777d06785a9d43d3e485659152aab0L30) [[3]](diffhunk://#diff-7838b4c0b22c76b91224b2ea64848c8115916c04e7a79875f957f1284ae75596L20-R21) [[4]](diffhunk://#diff-6edc5c48eb59d1ea777c72db171e08dcb6ca5e5b13eb70cce56d947ad24f4801L74-R74) [[5]](diffhunk://#diff-09ee95e84aee4cf02abc8a19d23fdd7d037f0edbf13276413985f29311972817L20-R20)

**Admin and Sidebar Improvements**

* Skills in the admin CV sidebar are now rendered as links to their detail pages, and the sidebar's list styling is improved. [[1]](diffhunk://#diff-ebf99394d42f40444180ffad54657d1047e88faad515449ecc89d614463c1686R13-R18) [[2]](diffhunk://#diff-c27f29a4082eee5a9afe82fe211fae29d2299ecf6d7f2e1b3d4bfc9fd05edd59L116-R118)

**Testing and Mock Improvements**

* The `marked` markdown parser mock is updated for better compatibility with Jest and the real API.
* The `ContentSidebar` tests are improved to accurately reflect the component's behavior when children are missing or present, ensuring correct DOM structure. [[1]](diffhunk://#diff-75178ed3e6c8a56e6c9ee95c8f3fc69f5c92099959868bb71d3bd4e917e1c402L50-R69) [[2]](diffhunk://#diff-75178ed3e6c8a56e6c9ee95c8f3fc69f5c92099959868bb71d3bd4e917e1c402L124-R124) [[3]](diffhunk://#diff-75178ed3e6c8a56e6c9ee95c8f3fc69f5c92099959868bb71d3bd4e917e1c402L134-R134) [[4]](diffhunk://#diff-75178ed3e6c8a56e6c9ee95c8f3fc69f5c92099959868bb71d3bd4e917e1c402L167-R167) [[5]](diffhunk://#diff-75178ed3e6c8a56e6c9ee95c8f3fc69f5c92099959868bb71d3bd4e917e1c402L341-R341) [[6]](diffhunk://#diff-75178ed3e6c8a56e6c9ee95c8f3fc69f5c92099959868bb71d3bd4e917e1c402L363-R369) [[7]](diffhunk://#diff-75178ed3e6c8a56e6c9ee95c8f3fc69f5c92099959868bb71d3bd4e917e1c402L377-R388)

**Other Minor Updates**

* Version bumps in `package.json` and `README.md` to `1.4.1`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R1)
* Minor text and style tweaks in PDF language proficiency and markdown rendering. [[1]](diffhunk://#diff-55bada8eeca26182af4f677e0605b52f3f4f582fa73d7a3451d5e4882eba32efL23) [[2]](diffhunk://#diff-3a430ee0f9d9678a515204f75f066817aee19ed50aafa32fe6507e499022493fL25-R32)

Let me know if you want a walkthrough of any specific part of these changes!

### Sub-tasks
* [FRD-157] Sort experiences by end_date (#146)
Experiences and educations are now sorted by end_date descending in all relevant components and PDF templates. Experience and education tiles have improved UX: they are now non-selectable, have hover backgrounds, and ExperienceTile is clickable to navigate to the admin experience detail. Skill badges in the admin sidebar now link to their skill detail page.

* [FRD-158] Display experience title on the dashboard table
Replaces the 'Type' column with a 'Title' column, adjusts column widths, and updates the 'Skills' and 'Start Date' columns with new min/max width settings. Removes the type formatting logic to simplify the configuration.

* [FRD-160] Render markdown on CV summary
Updated CVPDFEducation and CVPDFSummary components to use the parseCSS helper for combining class names passed to the Markdown component. This ensures consistent styling when multiple CSS modules are applied.

* [FRD-159] Add margin-bottom to the skills badge
Introduced a new .skillsList style in the SCSS module to add spacing between skill links. Updated the CVDetailsSidebar component to use the new styled class instead of a plain className for consistent styling.

* [FRD-161] Hide empty content blocks and remove titles (#147)
Updated CVPDFExperience to conditionally render summary, description, and responsibilities only if present, removing unnecessary headings. Adjusted ContentSidebar to only render the sidebar if content exists. Minor style tweak to experience list item spacing.

* [FRD-162] Improve UI for language title
Eliminated the static proficiency label from the CVPDFLanguages component to streamline the display of language proficiency.

* [FRD-165] Render chat messages from markdown (#148)
Replaced plain text rendering of chat messages with the Markdown component to support rich text formatting. Updated related SCSS to adjust spacing and list styles for both unordered and ordered lists.

[FRD-156]: https://feliperamosdev.atlassian.net/browse/FRD-156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[FRD-157]: https://feliperamosdev.atlassian.net/browse/FRD-157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ