### PR TITLE
[FRD-180] Favorite CV Feature

### DIFF
--- a/src/components/buttons/FavoriteButton/FavoriteButton.module.scss
+++ b/src/components/buttons/FavoriteButton/FavoriteButton.module.scss
@@ -3,8 +3,4 @@
 .FavoriteButton {
    cursor: pointer;
    transition: color 0.3s ease;
-
-   &:hover {
-      color: var(--color-primary);
-   }
 }

--- a/src/components/buttons/FavoriteButton/FavoriteButton.module.scss
+++ b/src/components/buttons/FavoriteButton/FavoriteButton.module.scss
@@ -1,0 +1,10 @@
+@use '@/style/variables' as *;
+
+.FavoriteButton {
+   cursor: pointer;
+   transition: color 0.3s ease;
+
+   &:hover {
+      color: var(--color-primary);
+   }
+}

--- a/src/components/buttons/FavoriteButton/FavoriteButton.tsx
+++ b/src/components/buttons/FavoriteButton/FavoriteButton.tsx
@@ -14,7 +14,7 @@ export default function FavoriteButton({ isFavorite, iconSize = 'medium', spinne
          setLoading(true);
          await onClick();
       } catch (error) {
-         console.log(error);
+         console.error(error);
       } finally {
          setLoading(false);
       }

--- a/src/components/buttons/FavoriteButton/FavoriteButton.tsx
+++ b/src/components/buttons/FavoriteButton/FavoriteButton.tsx
@@ -1,0 +1,35 @@
+import { Star, StarBorder } from '@mui/icons-material';
+import { FavoriteButtonProps } from './FavoriteButton.types';
+import { parseCSS } from '@/helpers/parse.helpers';
+import styles from './FavoriteButton.module.scss';
+import { useState } from 'react';
+import { Spinner } from '@/components/common';
+
+export default function FavoriteButton({ isFavorite, iconSize = 'medium', spinnerSize = '1.5rem', className, onClick = async () => {} }: FavoriteButtonProps) {
+   const [ loading, setLoading ] = useState<boolean>(false);
+   const Icon = isFavorite ? Star : StarBorder;
+
+   const handleClick = async () => {
+      try {
+         setLoading(true);
+         await onClick();
+      } catch (error) {
+         console.log(error);
+      } finally {
+         setLoading(false);
+      }
+   }
+
+   const classes = parseCSS(className, [
+      styles.FavoriteButton
+   ]);
+
+   if (loading) {
+      return <Spinner size={spinnerSize} />
+   }
+
+   return (
+      <Icon className={classes} fontSize={iconSize} onClick={handleClick} />
+   );
+}
+   

--- a/src/components/buttons/FavoriteButton/FavoriteButton.types.ts
+++ b/src/components/buttons/FavoriteButton/FavoriteButton.types.ts
@@ -1,0 +1,7 @@
+export interface FavoriteButtonProps {
+   className?: string | string[];
+   iconSize?: 'small' | 'medium' | 'large';
+   spinnerSize?: string;
+   onClick: () => void | Promise<void>;
+   isFavorite: boolean;
+}

--- a/src/components/buttons/index.tsx
+++ b/src/components/buttons/index.tsx
@@ -1,3 +1,4 @@
 export { default as CTAButton } from './CTAButton/CTAButton';
 export { default as RoundButton } from './RoundButton/RoundButton';
 export { default as EditButtons } from './EditButtons/EditButtons';
+export { default as FavoriteButton } from './FavoriteButton/FavoriteButton';

--- a/src/components/content/admin/curriculum/CVDetailsContent/CVDetailsContent.module.scss
+++ b/src/components/content/admin/curriculum/CVDetailsContent/CVDetailsContent.module.scss
@@ -16,6 +16,17 @@
    }
 }
 
+.cvTitle {
+   display: inline-flex;
+   align-items: center;
+   gap: 0.5rem;
+   width: fit-content;
+
+   >div {
+      width: fit-content;
+   }
+}
+
 .pdfDownload {
    width: 100%;
    display: flex;

--- a/src/components/content/admin/curriculum/CVDetailsContent/subcomponents/CVDetailsInfos.tsx
+++ b/src/components/content/admin/curriculum/CVDetailsContent/subcomponents/CVDetailsInfos.tsx
@@ -4,15 +4,32 @@ import { WidgetHeader } from '@/components/headers';
 import { DataContainer } from '@/components/layout';
 import { useCVDetails } from '../CVDetailsContext';
 import { useState } from 'react';
-import { EditButtons } from '@/components/buttons';
+import { EditButtons, FavoriteButton } from '@/components/buttons';
 import { EditCVInfosForm } from '@/components/forms/curriculums';
 import { useTextResources } from '@/services/TextResources/TextResourcesProvider';
 import texts from '../CVDetailsContent.text';
+import { useAjax } from '@/hooks/useAjax';
+import styles from '../CVDetailsContent.module.scss';
 
 export default function CVDetailsInfos({ cardProps }: CVDetailsSubcomponentProps): React.ReactElement {
    const [ editMode, setEditMode ] = useState<boolean>(false);
    const { textResources } = useTextResources(texts);
+   const ajax = useAjax();
    const cv = useCVDetails();
+
+   const handleFavorite = async () => {
+      try {
+         const favorited = await ajax.post('/curriculum/update', { id: cv.id, updates: { is_favorite: !cv.is_favorite } });
+
+         if (!favorited.success) {
+            throw new Error(favorited.message || 'Failed to toggle favorite');
+         }
+
+         window.location.reload();
+      } catch (error) {
+         console.error('Error toggling favorite:', error);
+      }
+   }
 
    return (
       <Card className="CVDetailsInfos" {...cardProps}>
@@ -27,7 +44,16 @@ export default function CVDetailsInfos({ cardProps }: CVDetailsSubcomponentProps
          {!editMode && (<>
             <DataContainer>
                <label>{textResources.getText('CVDetailsInfos.title.label')}</label>
-               <p>{cv.title}</p>
+
+               <span className={styles.cvTitle}>
+                  {cv.title}
+
+                  <FavoriteButton
+                     isFavorite={cv.is_favorite}
+                     // iconSize='small'
+                     onClick={handleFavorite}
+                  />
+               </span>
             </DataContainer>
             <DataContainer>
                <label>{textResources.getText('CVDetailsInfos.experienceTime.label')}</label>

--- a/src/components/content/admin/curriculum/CVDetailsContent/subcomponents/CVDetailsInfos.tsx
+++ b/src/components/content/admin/curriculum/CVDetailsContent/subcomponents/CVDetailsInfos.tsx
@@ -50,7 +50,6 @@ export default function CVDetailsInfos({ cardProps }: CVDetailsSubcomponentProps
 
                   <FavoriteButton
                      isFavorite={cv.is_favorite}
-                     // iconSize='small'
                      onClick={handleFavorite}
                   />
                </span>

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -66,6 +66,7 @@ export interface CVData extends CVSetData {
    title: string;
    experience_time?: number;
    is_master: boolean;
+   is_favorite: boolean;
    notes?: string;
    cv_experiences?: ExperienceData[];
    cv_skills?: SkillData[];


### PR DESCRIPTION
## [FRD-180] Description
This pull request introduces a new `FavoriteButton` component and integrates it into the CV details view, allowing users to mark a CV as favorite. The changes include the creation of the button component, styling updates, type additions, and the necessary logic to toggle the favorite status with backend integration. The most important changes are grouped below:

**New Favorite Button Component:**

* Added the new `FavoriteButton` component, including its TypeScript, SCSS, and types definition files (`FavoriteButton.tsx`, `FavoriteButton.module.scss`, `FavoriteButton.types.ts`). This button displays a star icon, shows a spinner when loading, and handles asynchronous favorite toggling. [[1]](diffhunk://#diff-cb8677306bcdd7050e11f8a83ea053d96dbbba2fed71ea1e89ec974a142063b5R1-R35) [[2]](diffhunk://#diff-5f35e4474c534db66c2cfdb6731139725fe818d58284c89513e1bcdfe755bf87R1-R10) [[3]](diffhunk://#diff-71fc91cfa47d3506f453039223deee3e3bac74ff77a5a486950ab1ce066c7fecR1-R7)
* Exported `FavoriteButton` from the main buttons index for use across the app (`index.tsx`).

**Integration into CV Details:**

* Integrated the `FavoriteButton` into the `CVDetailsInfos` component, next to the CV title. Added logic to handle favorite toggling via an AJAX call and page reload on success. [[1]](diffhunk://#diff-df9ecab4744f829a477aeac9e4ff6de17e9dc17a1ede84f4170fa30683daaa1fL7-R33) [[2]](diffhunk://#diff-df9ecab4744f829a477aeac9e4ff6de17e9dc17a1ede84f4170fa30683daaa1fL30-R56)
* Added new styling for the CV title area to support the inline favorite button (`CVDetailsContent.module.scss`).

**Type and Data Model Updates:**

* Extended the `CVData` interface to include the `is_favorite` boolean property, enabling type-safe favorite tracking for CVs.

[FRD-180]: https://feliperamosdev.atlassian.net/browse/FRD-180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ