### PR TITLE
[FRD-182] Add job title and company fields to custom CV generation

### DIFF
--- a/src/components/forms/curriculums/GenerateCustomCVForm/GenerateCustomCVForm.tsx
+++ b/src/components/forms/curriculums/GenerateCustomCVForm/GenerateCustomCVForm.tsx
@@ -39,6 +39,14 @@ export default function GenerateCustomCVForm({ initialValues, viewType, classNam
                   label="Custom Prompt"
                   multiline
                />
+               <FormInput
+                  fieldName="jobTitle"
+                  label="Job Title"
+               />
+               <FormInput
+                  fieldName="jobCompany"
+                  label="Job Company"
+               />
 
                <FormSubmit className={styles.generateButton} label="Re-Generate" color="primary" />
             </div>

--- a/src/components/modals/GenerateCustomCVModal/GenerateCustomCVModal.tsx
+++ b/src/components/modals/GenerateCustomCVModal/GenerateCustomCVModal.tsx
@@ -52,7 +52,7 @@ export default function GenerateCustomCVModal({ className, genSummaryParams, isO
       setGenParams(null);
 
       emit('generate-summary', { ...genParams, ...data }, (response: unknown) => {
-         const { summary, jobDescription, aiThread } = response as GenerateSummarySuccess;
+         const { summary, jobDescription, jobTitle, jobCompany, aiThread } = response as GenerateSummarySuccess;
          const { error } = response as GenerateSummaryError;
 
          if (error) {
@@ -62,6 +62,8 @@ export default function GenerateCustomCVModal({ className, genSummaryParams, isO
          }
 
          setGenParams((prev) => ({
+            jobTitle: jobTitle || null,
+            jobCompany: jobCompany || null,
             ...prev,
             currentInput: summary || null,
             jobDescription: jobDescription || null,
@@ -104,7 +106,7 @@ export default function GenerateCustomCVModal({ className, genSummaryParams, isO
          notes: undefined,
          is_master: undefined,
          summary: genParams?.currentInput,
-         title: `${cvTemplate.title} (${new Date().toLocaleString()})`,
+         title: `${genParams?.jobCompany} | ${genParams?.jobTitle}`,
          cv_educations: cvTemplate.cv_educations?.map((edu) => (edu as EducationData).id),
          cv_experiences: cvTemplate.cv_experiences?.map((exp) => (exp as ExperienceData).id),
          cv_languages: cvTemplate.cv_languages?.map((lang) => (lang as LanguageData).id),

--- a/src/components/modals/GenerateCustomCVModal/GenerateCustomCVModal.types.ts
+++ b/src/components/modals/GenerateCustomCVModal/GenerateCustomCVModal.types.ts
@@ -11,6 +11,8 @@ export interface GenerateCustomCVModalProps {
 
 export interface GenerateSummarySuccess {
    summary: string;
+   jobTitle: string;
+   jobCompany: string;
    jobDescription: string;
    aiThread: string;
 }

--- a/src/components/widgets/CustomCVWidget/CustomCVWidget.types.ts
+++ b/src/components/widgets/CustomCVWidget/CustomCVWidget.types.ts
@@ -4,6 +4,8 @@ export interface CustomCVWidgetProps {
 
 export interface GenerateSummaryParams {
    jobURL?: string;
+   jobTitle?: string;
+   jobCompany?: string;
    jobDescription?: string;
    customPrompt?: string;
    currentInput?: string;


### PR DESCRIPTION
## [FRD-182] Description
This pull request enhances the custom CV generation workflow by adding support for capturing and utilizing the job title and company name throughout the form, modal, and data structures. These changes ensure that the generated CVs can be more personalized based on the specific job and company, and that this information is consistently passed and displayed.

**Form and UI enhancements:**
- Added `jobTitle` and `jobCompany` input fields to the `GenerateCustomCVForm` component, allowing users to specify the job title and company for the CV they're generating.

**Data flow and state management:**
- Updated the `GenerateSummarySuccess` and `GenerateSummaryParams` interfaces to include `jobTitle` and `jobCompany`, ensuring these fields are available throughout the CV generation process. [[1]](diffhunk://#diff-853e86be8113807a4732bfa4289ab596f1b4a151b1e530d14b04fba655ac46dbR14-R15) [[2]](diffhunk://#diff-1463a93c86b79fc3a59abc3f5b64a02f22b7fde6d8f08b1b62aea7dfa6086bb8R7-R8)
- Modified the `GenerateCustomCVModal` component to handle `jobTitle` and `jobCompany` in the response from the summary generation event and to store them in the modal's state. [[1]](diffhunk://#diff-18d544ba09e8637a685d8e7c44377a5e0ef1b55c8c996a2a6367281efb3bc5c0L55-R55) [[2]](diffhunk://#diff-18d544ba09e8637a685d8e7c44377a5e0ef1b55c8c996a2a6367281efb3bc5c0R65-R66)

**CV output improvements:**
- Changed the CV title generation logic to use the job company and job title, making the resulting CVs more relevant to the user's target position.