### PR TITLE
[FRD-194] Improving best practices for HTTP method

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -6,6 +6,10 @@ console.error = (...args) => {
    if (args[0]?.message?.includes('Not implemented: HTMLFormElement.prototype.requestSubmit')) {
       return;
    }
+   // Suppress navigation errors from window.location.reload in tests
+   if (args[0]?.message?.includes('Not implemented: navigation')) {
+      return;
+   }
    originalConsoleError(...args);
 };
 
@@ -21,6 +25,7 @@ jest.mock('@/services', () => ({
       get: jest.fn(),
       post: jest.fn(),
       put: jest.fn(),
+      patch: jest.fn(),
       delete: jest.fn()
    }))
 }));

--- a/src/components/content/admin/company/CompanyDetailsContent/slices/CompanyDetailsSets.tsx
+++ b/src/components/content/admin/company/CompanyDetailsContent/slices/CompanyDetailsSets.tsx
@@ -31,8 +31,8 @@ export default function CompanyDetailsSets(): React.ReactElement {
 
          <TabsContent
             options={tabOptions}
-            useNewButton
             newContent={<EditCompanySetForm />}
+            useNewButton
          >
             {tabOptions.map((option: TabOption) => {
                const languageSet = company.languageSets.find(set => set.language_set === option.value);

--- a/src/components/content/admin/company/CompanyDetailsContent/slices/CompanyDetailsSidebar.tsx
+++ b/src/components/content/admin/company/CompanyDetailsContent/slices/CompanyDetailsSidebar.tsx
@@ -25,7 +25,7 @@ export default function CompanyDetailsSidebar(): React.ReactElement {
 
       try {
          setDeleteLoading(true);
-         const deleted = await ajax.post('/company/delete', { companyId: company?.id });
+         const deleted = await ajax.delete('/company/delete', { params: { companyId: company?.id } });
          if (!deleted.success) {
             return deleted;
          }

--- a/src/components/content/admin/curriculum/CVDetailsContent/subcomponents/CVDetailsInfos.tsx
+++ b/src/components/content/admin/curriculum/CVDetailsContent/subcomponents/CVDetailsInfos.tsx
@@ -19,7 +19,7 @@ export default function CVDetailsInfos({ cardProps }: CVDetailsSubcomponentProps
 
    const handleFavorite = async () => {
       try {
-         const favorited = await ajax.post('/curriculum/update', { id: cv.id, updates: { is_favorite: !cv.is_favorite } });
+         const favorited = await ajax.patch('/curriculum/update', { id: cv.id, updates: { is_favorite: !cv.is_favorite } });
 
          if (!favorited.success) {
             throw new Error(favorited.message || 'Failed to toggle favorite');

--- a/src/components/content/admin/curriculum/CVDetailsContent/subcomponents/CVDetailsSidebar.tsx
+++ b/src/components/content/admin/curriculum/CVDetailsContent/subcomponents/CVDetailsSidebar.tsx
@@ -39,7 +39,7 @@ export default function CVDetailsSidebar({ cardProps }: CVDetailsSubcomponentPro
 
       try {
          setDeleteLoading(true);
-         const deleted = await ajax.post('/curriculum/delete', { cvId: cv?.id });
+         const deleted = await ajax.delete('/curriculum/delete', { params: { cvId: cv?.id } });
          if (!deleted.success) {
             return deleted;
          }

--- a/src/components/content/admin/experience/ExperienceDetailsContent/common/ExperienceDetailsSidebar.tsx
+++ b/src/components/content/admin/experience/ExperienceDetailsContent/common/ExperienceDetailsSidebar.tsx
@@ -36,7 +36,7 @@ export default function ExperienceDetailsSidebar(): React.ReactElement {
 
       try {
          setDeleteLoading(true);
-         const deleted = await ajax.post('/experience/delete', { experienceId: experience?.id });
+         const deleted = await ajax.delete('/experience/delete', { params: { experienceId: experience?.id } });
          if (!deleted.success) {
             return deleted;
          }

--- a/src/components/content/admin/skill/SkillDetailsContent/subcomponents/SkillDetailsSidebar.tsx
+++ b/src/components/content/admin/skill/SkillDetailsContent/subcomponents/SkillDetailsSidebar.tsx
@@ -25,7 +25,7 @@ export default function SkillDetailsSidebar(): React.ReactElement {
 
       try {
          setDeleteLoading(true);
-         const deleted = await ajax.post('/skill/delete', { skillId: skill?.id });
+         const deleted = await ajax.delete('/skill/delete', { params: { skillId: skill?.id } });
          if (!deleted.success) {
             return deleted;
          }

--- a/src/components/forms/companies/EditCompanyInfo/EditCompanyInfo.test.tsx
+++ b/src/components/forms/companies/EditCompanyInfo/EditCompanyInfo.test.tsx
@@ -99,10 +99,11 @@ jest.mock('@/hooks', () => ({
 }));
 
 // Mock useAjax hook
-const mockPost = jest.fn();
+const mockPatch = jest.fn();
 jest.mock('@/hooks/useAjax', () => ({
    useAjax: () => ({
-      post: mockPost
+      post: mockPatch,
+      patch: mockPatch
    })
 }));
 
@@ -347,7 +348,7 @@ describe('EditCompanyInfo', () => {
 
    describe('Form Submission', () => {
       test('handles successful form submission', async () => {
-         mockPost.mockResolvedValue({
+         mockPatch.mockResolvedValue({
             success: true,
             data: { ...mockCompanyData, company_name: 'Updated Company' }
          });
@@ -363,7 +364,7 @@ describe('EditCompanyInfo', () => {
          fireEvent.submit(screen.getByTestId('edit-form'));
 
          await waitFor(() => {
-            expect(mockPost).toHaveBeenCalledWith('/company/update', {
+            expect(mockPatch).toHaveBeenCalledWith('/company/update', {
                id: 1,
                updates: expect.objectContaining({
                   company_name: 'Updated Company'
@@ -375,7 +376,7 @@ describe('EditCompanyInfo', () => {
       test('handles API error response', async () => {
          const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
          
-         mockPost.mockResolvedValue({
+         mockPatch.mockResolvedValue({
             success: false,
             message: 'Company not found'
          });
@@ -385,7 +386,7 @@ describe('EditCompanyInfo', () => {
          fireEvent.submit(screen.getByTestId('edit-form'));
 
          await waitFor(() => {
-            expect(mockPost).toHaveBeenCalled();
+            expect(mockPatch).toHaveBeenCalled();
          });
 
          expect(consoleSpy).toHaveBeenCalledWith('Company not found or update failed');
@@ -396,14 +397,14 @@ describe('EditCompanyInfo', () => {
       test('handles network error', async () => {
          const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
          
-         mockPost.mockRejectedValue(new Error('Network error'));
+         mockPatch.mockRejectedValue(new Error('Network error'));
 
          render(<EditCompanyInfo />);
          
          fireEvent.submit(screen.getByTestId('edit-form'));
 
          await waitFor(() => {
-            expect(mockPost).toHaveBeenCalled();
+            expect(mockPatch).toHaveBeenCalled();
          });
 
          expect(consoleSpy).toHaveBeenCalledWith('Error updating company:', expect.any(Error));
@@ -412,7 +413,7 @@ describe('EditCompanyInfo', () => {
       });
 
       test('submits form with all updated field values', async () => {
-         mockPost.mockResolvedValue({
+         mockPatch.mockResolvedValue({
             success: true,
             data: mockCompanyData
          });
@@ -436,7 +437,7 @@ describe('EditCompanyInfo', () => {
          fireEvent.submit(screen.getByTestId('edit-form'));
 
          await waitFor(() => {
-            expect(mockPost).toHaveBeenCalledWith('/company/update', {
+            expect(mockPatch).toHaveBeenCalledWith('/company/update', {
                id: 1,
                updates: {
                   company_name: 'New Company Name',
@@ -449,7 +450,7 @@ describe('EditCompanyInfo', () => {
       });
 
       test('includes company ID in update request', async () => {
-         mockPost.mockResolvedValue({
+         mockPatch.mockResolvedValue({
             success: true,
             data: mockCompanyData
          });
@@ -459,7 +460,7 @@ describe('EditCompanyInfo', () => {
          fireEvent.submit(screen.getByTestId('edit-form'));
 
          await waitFor(() => {
-            expect(mockPost).toHaveBeenCalledWith('/company/update', 
+            expect(mockPatch).toHaveBeenCalledWith('/company/update', 
                expect.objectContaining({
                   id: 1
                })
@@ -472,11 +473,11 @@ describe('EditCompanyInfo', () => {
       test('uses useAjax hook for API calls', () => {
          render(<EditCompanyInfo />);
          
-         expect(mockPost).toBeDefined();
+         expect(mockPatch).toBeDefined();
       });
 
       test('makes POST request to correct endpoint', async () => {
-         mockPost.mockResolvedValue({
+         mockPatch.mockResolvedValue({
             success: true,
             data: mockCompanyData
          });
@@ -486,14 +487,14 @@ describe('EditCompanyInfo', () => {
          fireEvent.submit(screen.getByTestId('edit-form'));
 
          await waitFor(() => {
-            expect(mockPost).toHaveBeenCalledWith('/company/update', expect.any(Object));
+            expect(mockPatch).toHaveBeenCalledWith('/company/update', expect.any(Object));
          });
       });
 
       test('handles undefined API response', async () => {
          const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
          
-         mockPost.mockResolvedValue(undefined);
+         mockPatch.mockResolvedValue(undefined);
 
          render(<EditCompanyInfo />);
          
@@ -565,7 +566,7 @@ describe('EditCompanyInfo', () => {
       test('validates form submission error handling', async () => {
          const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
          
-         mockPost.mockResolvedValue({
+         mockPatch.mockResolvedValue({
             success: false
          });
 
@@ -574,7 +575,7 @@ describe('EditCompanyInfo', () => {
          fireEvent.submit(screen.getByTestId('edit-form'));
          
          await waitFor(() => {
-            expect(mockPost).toHaveBeenCalled();
+            expect(mockPatch).toHaveBeenCalled();
          });
          
          expect(consoleSpy).toHaveBeenCalled();

--- a/src/components/forms/companies/EditCompanyInfo/EditCompanyInfo.tsx
+++ b/src/components/forms/companies/EditCompanyInfo/EditCompanyInfo.tsx
@@ -13,7 +13,7 @@ export default function EditCompanyInfo(): React.JSX.Element {
 
    const handleSubmit = async (data: FormValues) => {
       try {
-         const updated = await ajax.post<CompanyData>('/company/update', {
+         const updated = await ajax.patch<CompanyData>('/company/update', {
             id: company.id,
             updates: data,
          });

--- a/src/components/forms/companies/EditCompanySetForm/EditCompanySetForm.test.tsx
+++ b/src/components/forms/companies/EditCompanySetForm/EditCompanySetForm.test.tsx
@@ -174,7 +174,8 @@ jest.mock('@/hooks/Form/inputs/FormSelect', () => {
 const mockPost = jest.fn();
 jest.mock('@/hooks/useAjax', () => ({
    useAjax: () => ({
-      post: mockPost
+      post: mockPost,
+      patch: mockPost  // Both create and edit mode use the same mock for simplicity
    })
 }));
 

--- a/src/components/forms/companies/EditCompanySetForm/EditCompanySetForm.tsx
+++ b/src/components/forms/companies/EditCompanySetForm/EditCompanySetForm.tsx
@@ -41,7 +41,7 @@ export default function EditCompanySetForm({ language_set, editMode }: { languag
          }
       } else {
          try {
-            const updated = await ajax.post<CompanySetData>('/company/update-set', {
+            const updated = await ajax.patch<CompanySetData>('/company/update-set', {
                id: languageSet?.id,
                updates: values
             });

--- a/src/components/forms/curriculums/EditCVEducationsForm/EditCVEducationsForm.tsx
+++ b/src/components/forms/curriculums/EditCVEducationsForm/EditCVEducationsForm.tsx
@@ -20,7 +20,7 @@ export default function EditCVEducationsForm(): React.ReactElement {
 
    const handleSubmit = async (values: FormValues) => {
       try {
-         const response = await ajax.post<CVData>('/curriculum/update', { id: cv.id, updates: values });
+         const response = await ajax.patch<CVData>('/curriculum/update', { id: cv.id, updates: values });
 
          if (response.error) {
             throw response;

--- a/src/components/forms/curriculums/EditCVExperiencesForm/EditCVExperiencesForm.test.tsx
+++ b/src/components/forms/curriculums/EditCVExperiencesForm/EditCVExperiencesForm.test.tsx
@@ -80,6 +80,7 @@ const mockAjax = {
    get: jest.fn(),
    post: jest.fn(),
    put: jest.fn(),
+   patch: jest.fn(),
    delete: jest.fn()
 };
 
@@ -165,7 +166,7 @@ describe('EditCVExperiencesForm', () => {
          success: true, 
          data: { id: 123, title: 'Updated CV' }
       };
-      mockAjax.post.mockResolvedValue(mockResponse);
+      mockAjax.patch.mockResolvedValue(mockResponse);
 
       render(<EditCVExperiencesForm />);
 
@@ -173,7 +174,7 @@ describe('EditCVExperiencesForm', () => {
       fireEvent.submit(form);
 
       await waitFor(() => {
-         expect(mockAjax.post).toHaveBeenCalledWith('/curriculum/update', {
+         expect(mockAjax.patch).toHaveBeenCalledWith('/curriculum/update', {
             id: 123,
             updates: { cv_experiences: [1, 3] }
          });
@@ -259,7 +260,7 @@ describe('EditCVExperiencesForm', () => {
 
    it('handles successful update with data validation', async () => {
       const mockResponse = { success: true, data: { id: 123 } };
-      mockAjax.post.mockResolvedValue(mockResponse);
+      mockAjax.patch.mockResolvedValue(mockResponse);
 
       render(<EditCVExperiencesForm />);
 
@@ -267,7 +268,7 @@ describe('EditCVExperiencesForm', () => {
       fireEvent.click(submitButton);
 
       await waitFor(() => {
-         expect(mockAjax.post).toHaveBeenCalledWith('/curriculum/update', {
+         expect(mockAjax.patch).toHaveBeenCalledWith('/curriculum/update', {
             id: 123,
             updates: { cv_experiences: [1, 3] }
          });

--- a/src/components/forms/curriculums/EditCVExperiencesForm/EditCVExperiencesForm.tsx
+++ b/src/components/forms/curriculums/EditCVExperiencesForm/EditCVExperiencesForm.tsx
@@ -16,7 +16,7 @@ export default function EditCVExperiencesForm(): React.ReactElement {
 
    const handleSubmit = async (data: FormValues) => {
       try {
-         const updatedCV = await ajax.post<CVData>('/curriculum/update', { id: cv.id, updates: data });
+         const updatedCV = await ajax.patch<CVData>('/curriculum/update', { id: cv.id, updates: data });
 
          if (!updatedCV.success) {
             throw updatedCV;

--- a/src/components/forms/curriculums/EditCVInfosForm/EditCVInfosForm.tsx
+++ b/src/components/forms/curriculums/EditCVInfosForm/EditCVInfosForm.tsx
@@ -14,7 +14,7 @@ export default function EditCVInfosForm() {
 
    const handleSubmit = async (data: FormValues) => {
       try {
-         const updatedCV = await ajax.post<CVData>('/curriculum/update', { id: cv.id, updates: data });
+         const updatedCV = await ajax.patch<CVData>('/curriculum/update', { id: cv.id, updates: data });
 
          if (!updatedCV.success) {
             throw updatedCV;

--- a/src/components/forms/curriculums/EditCVLanguagesForm/EditCVLanguagesForm.tsx
+++ b/src/components/forms/curriculums/EditCVLanguagesForm/EditCVLanguagesForm.tsx
@@ -20,7 +20,7 @@ export default function EditCVLanguagesForm(): React.ReactElement {
 
    const handleSubmit = async (values: FormValues) => {
       try {
-         const response = await ajax.post<CVData>('/curriculum/update', { id: cv.id, updates: values });
+         const response = await ajax.patch<CVData>('/curriculum/update', { id: cv.id, updates: values });
 
          if (response.error) {
             throw response;

--- a/src/components/forms/curriculums/EditCVMasterForm/EditCVMasterForm.tsx
+++ b/src/components/forms/curriculums/EditCVMasterForm/EditCVMasterForm.tsx
@@ -16,7 +16,7 @@ export default function EditCVMasterForm() {
       setLoading(true);
 
       try {
-         const updatedMaster = await ajax.post<CVData>('/curriculum/set-master', { cv_id: cv.id });
+         const updatedMaster = await ajax.patch<CVData>('/curriculum/set-master', { cv_id: cv.id });
 
          if (!updatedMaster.success) {
             throw updatedMaster;

--- a/src/components/forms/curriculums/EditCVSetForm/EditCVSetForm.tsx
+++ b/src/components/forms/curriculums/EditCVSetForm/EditCVSetForm.tsx
@@ -36,7 +36,7 @@ export default function EditCVSetForm({ editMode, language_set }: EditCVSetFormP
                throw new Error('Language set not found');
             }
 
-            const updatedCV = await ajax.post<CVSetData>('/curriculum/update-set', { id: languageSet.id, updates: data });
+            const updatedCV = await ajax.patch<CVSetData>('/curriculum/update-set', { id: languageSet.id, updates: data });
             if (!updatedCV.success) {
                throw updatedCV;
             }

--- a/src/components/forms/curriculums/EditCVSkillsForm/EditCVSkillsForm.tsx
+++ b/src/components/forms/curriculums/EditCVSkillsForm/EditCVSkillsForm.tsx
@@ -14,7 +14,7 @@ export default function EditCVSkillsForm() {
 
    const handleSubmit = async (data: FormValues) => {
       try {
-         const updatedSkills = await ajax.post('curriculum/update', { id: cv.id, updates: data });
+         const updatedSkills = await ajax.patch('curriculum/update', { id: cv.id, updates: data });
 
          if (!updatedSkills.success) {
             throw updatedSkills;

--- a/src/components/forms/experiences/EditExperienceSetForm/EditExperienceSetForm.test.tsx
+++ b/src/components/forms/experiences/EditExperienceSetForm/EditExperienceSetForm.test.tsx
@@ -81,7 +81,8 @@ jest.mock('./EditExperienceSetForm.text', () => ({}));
 
 describe('EditExperienceSetForm', () => {
    const mockAjax = {
-      post: jest.fn()
+      post: jest.fn(),
+      patch: jest.fn()
    };
 
    const mockTextResources = {
@@ -287,7 +288,7 @@ describe('EditExperienceSetForm', () => {
    // Form Submission Tests
    describe('Form Submission', () => {
       it('should handle successful form submission', async () => {
-         mockAjax.post.mockResolvedValue({ success: true });
+         mockAjax.patch.mockResolvedValue({ success: true });
          
          render(<EditExperienceSetForm {...defaultProps} />);
          
@@ -298,7 +299,7 @@ describe('EditExperienceSetForm', () => {
          });
          
          await waitFor(() => {
-            expect(mockAjax.post).toHaveBeenCalledWith('/experience/update-set', {
+            expect(mockAjax.patch).toHaveBeenCalledWith('/experience/update-set', {
                id: 'set-123',
                updates: mockExperience.languageSets[0]
             });
@@ -312,7 +313,7 @@ describe('EditExperienceSetForm', () => {
 
       it('should handle form submission error', async () => {
          const mockError = new Error('Update failed');
-         mockAjax.post.mockRejectedValue(mockError);
+         mockAjax.patch.mockRejectedValue(mockError);
          
          render(<EditExperienceSetForm {...defaultProps} />);
          
@@ -324,12 +325,12 @@ describe('EditExperienceSetForm', () => {
          });
          
          await waitFor(() => {
-            expect(mockAjax.post).toHaveBeenCalled();
+            expect(mockAjax.patch).toHaveBeenCalled();
          });
       });
 
       it('should handle null response from API', async () => {
-         mockAjax.post.mockResolvedValue(null);
+         mockAjax.patch.mockResolvedValue(null);
          
          render(<EditExperienceSetForm {...defaultProps} />);
          
@@ -364,7 +365,7 @@ describe('EditExperienceSetForm', () => {
             expect(screen.getByTestId('form-error')).toHaveTextContent('Language set not found');
          });
          
-         expect(mockAjax.post).not.toHaveBeenCalled();
+         expect(mockAjax.patch).not.toHaveBeenCalled();
       });
    });
 
@@ -403,7 +404,7 @@ describe('EditExperienceSetForm', () => {
    describe('Error Handling', () => {
       it('should handle Ajax error during submission', async () => {
          const mockError = new Error('Network error');
-         mockAjax.post.mockRejectedValue(mockError);
+         mockAjax.patch.mockRejectedValue(mockError);
          
          render(<EditExperienceSetForm {...defaultProps} />);
          

--- a/src/components/forms/experiences/EditExperienceSetForm/EditExperienceSetForm.tsx
+++ b/src/components/forms/experiences/EditExperienceSetForm/EditExperienceSetForm.tsx
@@ -18,7 +18,7 @@ export default function EditExperienceSetForm({ language_set = 'en' }: EditExper
       }
 
       try {
-         const updatedSet = await ajax.post<ExperienceSetData>('/experience/update-set', { id: languageSet.id, updates: values });
+         const updatedSet = await ajax.patch<ExperienceSetData>('/experience/update-set', { id: languageSet.id, updates: values });
 
          if (!updatedSet) {
             throw new Error('Failed to update experience set');

--- a/src/components/forms/skills/EditSkillForm/EditSkillForm.test.tsx
+++ b/src/components/forms/skills/EditSkillForm/EditSkillForm.test.tsx
@@ -91,7 +91,8 @@ jest.mock('@/app.config', () => ({
 
 describe('EditSkillForm', () => {
    const mockAjax = {
-      post: jest.fn()
+      post: jest.fn(),
+      patch: jest.fn()
    };
 
    const mockTextResources = {
@@ -225,7 +226,7 @@ describe('EditSkillForm', () => {
    // Form Submission Tests
    describe('Form Submission', () => {
       it('should handle successful form submission', async () => {
-         mockAjax.post.mockResolvedValue({ success: true });
+         mockAjax.patch.mockResolvedValue({ success: true });
          
          render(<EditSkillForm />);
          
@@ -233,7 +234,7 @@ describe('EditSkillForm', () => {
          await fireEvent.click(submitButton);
          
          await waitFor(() => {
-            expect(mockAjax.post).toHaveBeenCalledWith('/skill/update', {
+            expect(mockAjax.patch).toHaveBeenCalledWith('/skill/update', {
                id: 'skill-123',
                updates: mockSkill
             });
@@ -242,7 +243,7 @@ describe('EditSkillForm', () => {
 
       it('should handle form submission error', async () => {
          const mockError = new Error('Update failed');
-         mockAjax.post.mockRejectedValue(mockError);
+         mockAjax.patch.mockRejectedValue(mockError);
          
          render(<EditSkillForm />);
          
@@ -251,12 +252,12 @@ describe('EditSkillForm', () => {
          await fireEvent.click(submitButton);
          
          await waitFor(() => {
-            expect(mockAjax.post).toHaveBeenCalled();
+            expect(mockAjax.patch).toHaveBeenCalled();
          });
       });
 
       it('should handle unsuccessful response', async () => {
-         mockAjax.post.mockResolvedValue({ success: false, error: 'Validation failed' });
+         mockAjax.patch.mockResolvedValue({ success: false, error: 'Validation failed' });
          
          render(<EditSkillForm />);
          
@@ -265,19 +266,19 @@ describe('EditSkillForm', () => {
          await fireEvent.click(submitButton);
          
          await waitFor(() => {
-            expect(mockAjax.post).toHaveBeenCalled();
+            expect(mockAjax.patch).toHaveBeenCalled();
          });
       });
 
       it('should call handleSubmit with current skill data', async () => {
-         mockAjax.post.mockResolvedValue({ success: true });
+         mockAjax.patch.mockResolvedValue({ success: true });
          
          render(<EditSkillForm />);
          
          const submitButton = screen.getByRole('button');
          await fireEvent.click(submitButton);
          
-         expect(mockAjax.post).toHaveBeenCalledWith('/skill/update', {
+         expect(mockAjax.patch).toHaveBeenCalledWith('/skill/update', {
             id: mockSkill.id,
             updates: mockSkill
          });
@@ -362,7 +363,7 @@ describe('EditSkillForm', () => {
    describe('Error Handling', () => {
       it('should handle Ajax network errors', async () => {
          const networkError = new Error('Network error');
-         mockAjax.post.mockRejectedValue(networkError);
+         mockAjax.patch.mockRejectedValue(networkError);
          
          render(<EditSkillForm />);
          
@@ -371,13 +372,13 @@ describe('EditSkillForm', () => {
          await fireEvent.click(submitButton);
          
          await waitFor(() => {
-            expect(mockAjax.post).toHaveBeenCalled();
+            expect(mockAjax.patch).toHaveBeenCalled();
          });
       });
 
       it('should handle server validation errors', async () => {
          const validationError = { success: false, message: 'Invalid level value' };
-         mockAjax.post.mockResolvedValue(validationError);
+         mockAjax.patch.mockResolvedValue(validationError);
          
          render(<EditSkillForm />);
          
@@ -386,7 +387,7 @@ describe('EditSkillForm', () => {
          await fireEvent.click(submitButton);
          
          await waitFor(() => {
-            expect(mockAjax.post).toHaveBeenCalled();
+            expect(mockAjax.patch).toHaveBeenCalled();
          });
       });
 
@@ -469,7 +470,7 @@ describe('EditSkillForm', () => {
       });
 
       it('should handle rapid form submissions gracefully', async () => {
-         mockAjax.post.mockResolvedValue({ success: true });
+         mockAjax.patch.mockResolvedValue({ success: true });
          
          render(<EditSkillForm />);
          
@@ -481,11 +482,11 @@ describe('EditSkillForm', () => {
          fireEvent.click(submitButton);
          
          await waitFor(() => {
-            expect(mockAjax.post).toHaveBeenCalled();
+            expect(mockAjax.patch).toHaveBeenCalled();
          });
          
          // Should handle multiple submissions without errors
-         expect(mockAjax.post.mock.calls.length).toBeGreaterThan(0);
+         expect(mockAjax.patch.mock.calls.length).toBeGreaterThan(0);
       });
    });
 
@@ -500,7 +501,7 @@ describe('EditSkillForm', () => {
       });
 
       it('should handle complete form workflow', async () => {
-         mockAjax.post.mockResolvedValue({ success: true });
+         mockAjax.patch.mockResolvedValue({ success: true });
          
          render(<EditSkillForm />);
          
@@ -518,7 +519,7 @@ describe('EditSkillForm', () => {
          
          // Verify submission was handled
          await waitFor(() => {
-            expect(mockAjax.post).toHaveBeenCalled();
+            expect(mockAjax.patch).toHaveBeenCalled();
          });
       });
    });
@@ -526,28 +527,28 @@ describe('EditSkillForm', () => {
    // Data Validation Tests
    describe('Data Validation', () => {
       it('should pass correct skill ID in update request', async () => {
-         mockAjax.post.mockResolvedValue({ success: true });
+         mockAjax.patch.mockResolvedValue({ success: true });
          
          render(<EditSkillForm />);
          
          const submitButton = screen.getByRole('button');
          await fireEvent.click(submitButton);
          
-         expect(mockAjax.post).toHaveBeenCalledWith('/skill/update', {
+         expect(mockAjax.patch).toHaveBeenCalledWith('/skill/update', {
             id: mockSkill.id,
             updates: expect.any(Object)
          });
       });
 
       it('should include all skill fields in updates', async () => {
-         mockAjax.post.mockResolvedValue({ success: true });
+         mockAjax.patch.mockResolvedValue({ success: true });
          
          render(<EditSkillForm />);
          
          const submitButton = screen.getByRole('button');
          await fireEvent.click(submitButton);
          
-         expect(mockAjax.post).toHaveBeenCalledWith('/skill/update', {
+         expect(mockAjax.patch).toHaveBeenCalledWith('/skill/update', {
             id: mockSkill.id,
             updates: expect.objectContaining({
                name: expect.any(String),

--- a/src/components/forms/skills/EditSkillForm/EditSkillForm.tsx
+++ b/src/components/forms/skills/EditSkillForm/EditSkillForm.tsx
@@ -14,7 +14,7 @@ export default function EditSkillForm(): React.ReactElement {
 
    const handleSubmit = async (values: FormValues) => {
       try {
-         const response = await ajax.post<SkillData>('/skill/update', { id: skill.id, updates: values });
+         const response = await ajax.patch<SkillData>('/skill/update', { id: skill.id, updates: values });
 
          if (!response.success) {
             throw response;

--- a/src/components/forms/skills/EditSkillSetForm/EditSkillSetForm.test.tsx
+++ b/src/components/forms/skills/EditSkillSetForm/EditSkillSetForm.test.tsx
@@ -85,7 +85,8 @@ jest.mock('@/app.config', () => ({
 
 describe('EditSkillSetForm', () => {
    const mockAjax = {
-      post: jest.fn()
+      post: jest.fn(),
+      patch: jest.fn()
    };
 
    const mockTextResources = {
@@ -279,7 +280,7 @@ describe('EditSkillSetForm', () => {
    // Form Submission Tests - Edit Mode
    describe('Form Submission - Edit Mode', () => {
       it('should handle successful form submission in edit mode', async () => {
-         mockAjax.post.mockResolvedValue({ success: true });
+         mockAjax.patch.mockResolvedValue({ success: true });
          
          render(<EditSkillSetForm editMode={true} language_set="en" />);
          
@@ -287,8 +288,8 @@ describe('EditSkillSetForm', () => {
          await fireEvent.click(submitButton);
          
          await waitFor(() => {
-            expect(mockAjax.post).toHaveBeenCalledWith('/skill/update-set', {
-               id: 'skill-123',
+            expect(mockAjax.patch).toHaveBeenCalledWith('/skill/update-set', {
+               id: 'set-456',
                updates: mockSkill.languageSets[0]
             });
          });
@@ -296,7 +297,7 @@ describe('EditSkillSetForm', () => {
 
       it('should handle form submission error in edit mode', async () => {
          const mockError = new Error('Update failed');
-         mockAjax.post.mockRejectedValue(mockError);
+         mockAjax.patch.mockRejectedValue(mockError);
          
          render(<EditSkillSetForm editMode={true} language_set="en" />);
          
@@ -304,12 +305,12 @@ describe('EditSkillSetForm', () => {
          await fireEvent.click(submitButton);
          
          await waitFor(() => {
-            expect(mockAjax.post).toHaveBeenCalled();
+            expect(mockAjax.patch).toHaveBeenCalled();
          });
       });
 
       it('should handle unsuccessful response in edit mode', async () => {
-         mockAjax.post.mockResolvedValue({ success: false, error: 'Validation failed' });
+         mockAjax.patch.mockResolvedValue({ success: false, error: 'Validation failed' });
          
          render(<EditSkillSetForm editMode={true} language_set="en" />);
          
@@ -317,7 +318,7 @@ describe('EditSkillSetForm', () => {
          await fireEvent.click(submitButton);
          
          await waitFor(() => {
-            expect(mockAjax.post).toHaveBeenCalled();
+            expect(mockAjax.patch).toHaveBeenCalled();
          });
       });
    });

--- a/src/components/forms/skills/EditSkillSetForm/EditSkillSetForm.tsx
+++ b/src/components/forms/skills/EditSkillSetForm/EditSkillSetForm.tsx
@@ -29,7 +29,7 @@ export default function EditSkillSetForm({ editMode, language_set }: { editMode?
 
       try {
          if (editMode) {
-            response = await ajax.post<SkillSetData>('/skill/update-set', { id: skill.id, updates: values });
+            response = await ajax.patch<SkillSetData>('/skill/update-set', { id: languageSet?.id, updates: values });
          } else {
             response = await ajax.post<SkillSetData>('/skill/create-set', values);
          }

--- a/src/helpers/database.helpers.ts
+++ b/src/helpers/database.helpers.ts
@@ -11,7 +11,7 @@ export const handleExperienceUpdate = async (ajax: Ajax, experience: ExperienceD
    }
 
    try {
-      const updated = await ajax.post<ExperienceData>('/experience/update', {
+      const updated = await ajax.patch<ExperienceData>('/experience/update', {
          experienceId: experience.id,
          updates: values,
       });
@@ -135,7 +135,7 @@ export async function loadUserCVs(ajax: Ajax, textResources: TextResources): Pro
 
 export async function updateUserData(ajax: Ajax, data: FormValues): Promise<UserData> {
    try {
-      const updatedUser = await ajax.post<UserData>('/user/update', { updates: data });
+      const updatedUser = await ajax.patch<UserData>('/user/update', { updates: data });
 
       if (!updatedUser.success) {
          throw updatedUser;


### PR DESCRIPTION
## [FRD-194] Description
This pull request updates the API methods used throughout the admin content and form components to improve consistency and align with RESTful standards. The main change is replacing most `ajax.post` calls for updating and deleting resources with the more appropriate `ajax.patch` for updates and `ajax.delete` for deletions. This affects company, curriculum, experience, and skill management features across the codebase.

**API Method Standardization**

_Update operations switched from `ajax.post` to `ajax.patch`:_

* All update actions in forms for companies, curriculums, experiences, and skills now use `ajax.patch` instead of `ajax.post` for better RESTful compliance. This includes files like `EditCompanyInfo.tsx`, `EditCompanySetForm.tsx`, `EditCVInfosForm.tsx`, `EditCVSkillsForm.tsx`, `EditExperienceSetForm.tsx`, `EditSkillForm.tsx`, and related helpers. [[1]](diffhunk://#diff-225a40e86782b43c715811ca4b0e6fd17c0c573a89fce40fab80136e60c4748fL16-R16) [[2]](diffhunk://#diff-a3fd8887b2e9b8973415b25889e09b159c3bba1f8e99eace48fc1eb5038777e5L44-R44) [[3]](diffhunk://#diff-9381ee3a63dd5e30ec082c371ef70220a87631934d6e1f40c3c5e442d089ff85L17-R17) [[4]](diffhunk://#diff-e9e3ab60627e2eba374f1238f4db888e11f5754a81633126a591703d8a2ca895L17-R17) [[5]](diffhunk://#diff-026807de83fdce5f41f68116f483376859be01a1fbd21cedafa5ac198b9639faL21-R21) [[6]](diffhunk://#diff-ff41457a13b823d29a669b93df38e71177b6d2e436c15cda235e746f71dc7601L17-R17) [[7]](diffhunk://#diff-0716a1c2a7aabef86cfe340116f382528a8e28774b3824945b7cf6d133021133L14-R14) [[8]](diffhunk://#diff-0716a1c2a7aabef86cfe340116f382528a8e28774b3824945b7cf6d133021133L138-R138)

* Update set operations for company, curriculum, experience, and skill sets also now use `ajax.patch` for consistency. [[1]](diffhunk://#diff-a3fd8887b2e9b8973415b25889e09b159c3bba1f8e99eace48fc1eb5038777e5L44-R44) [[2]](diffhunk://#diff-33c360a3ba26ad15a989762781ad36fd5dc185870601cee1793b1bbdea71a1b1L39-R39) [[3]](diffhunk://#diff-026807de83fdce5f41f68116f483376859be01a1fbd21cedafa5ac198b9639faL21-R21) [[4]](diffhunk://#diff-c6f0595edb9a6c5dcc04d1ed9766b153133a921eb3cb77d7476920b2687a396cL32-R32)

_Delete operations switched from `ajax.post` to `ajax.delete`:_

* All sidebar delete actions for companies, curriculums, experiences, and skills now use `ajax.delete` with parameters passed in the `params` object, replacing previous `ajax.post` usage. [[1]](diffhunk://#diff-fa9a29cd5a9c8adb64a71919cb3c12afbc9974c679e269f4993d76a709c17023L28-R28) [[2]](diffhunk://#diff-c27f29a4082eee5a9afe82fe211fae29d2299ecf6d7f2e1b3d4bfc9fd05edd59L42-R42) [[3]](diffhunk://#diff-c84dab5bd9308950a88f1316cbf6054849a96c841e889294628e53fdc4ef6aa5L39-R39) [[4]](diffhunk://#diff-7af162444f72fdb40e5ffbfa26a52f4b615b4a202154a45bc1e128e0a13aa928L28-R28)

**Minor UI/Logic Fixes**

* Fixed the order of props in `CompanyDetailsSets.tsx` to ensure `useNewButton` is correctly passed to `TabsContent`.

These changes help ensure all resource updates and deletions follow best practices for HTTP methods, improving maintainability and clarity in the codebase.

[FRD-194]: https://feliperamosdev.atlassian.net/browse/FRD-194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ