### PR TITLE
[FRD-187] Opportunities Page Foundation

### DIFF
--- a/src/app/admin/opportunity/search/page.tsx
+++ b/src/app/admin/opportunity/search/page.tsx
@@ -1,0 +1,13 @@
+import { OpportunitySearch } from '@/components/content/admin/opportunity';
+import { AdminPageBase } from '@/components/layout';
+import { headersAcceptLanguage } from '@/helpers';
+
+export default async function OpportunitySearchPage() {
+   const locale = await headersAcceptLanguage();
+
+   return (
+      <AdminPageBase language={locale}>
+         <OpportunitySearch />
+      </AdminPageBase>
+   );
+}

--- a/src/components/content/admin/opportunity/OpportunitySearch/OpportunitySearch.tsx
+++ b/src/components/content/admin/opportunity/OpportunitySearch/OpportunitySearch.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { Container } from '@/components/common';
+import { PageHeader } from '@/components/headers';
+import { OpportunitiesTable } from '@/components/tables';
+
+export default function OpportunitySearch() {
+   return (
+      <div className="OpportunitySearch">
+         <PageHeader
+            title="Opportunities"
+            description="Search and manage opportunities"
+         />
+
+         <Container fullwidth>
+            <OpportunitiesTable />
+         </Container>
+      </div>
+   );
+}

--- a/src/components/content/admin/opportunity/index.tsx
+++ b/src/components/content/admin/opportunity/index.tsx
@@ -1,0 +1,1 @@
+export { default as OpportunitySearch } from './OpportunitySearch/OpportunitySearch';

--- a/src/components/menus/AdminMenu/AdminMenu.tsx
+++ b/src/components/menus/AdminMenu/AdminMenu.tsx
@@ -33,7 +33,7 @@ const MENU_ITEMS: MenuItem[] = [
    },
    {
       label: 'Opportunities',
-      href: '/admin/opportunities',
+      href: '/admin/opportunity/search',
       icon: <RequestQuote />,
    },
    {

--- a/src/components/tables/OpportunitiesTable/OpportunitiesTable.config.ts
+++ b/src/components/tables/OpportunitiesTable/OpportunitiesTable.config.ts
@@ -1,0 +1,24 @@
+import TableColumnConfig from "@/components/common/TableBase/TableColumnConfig";
+
+export const opportunitiesTableConfig: TableColumnConfig[] = [
+   {
+      propKey: 'id',
+      label: 'ID',
+      align: 'left'
+   },
+   {
+      propKey: 'job_title',
+      label: 'Job Title',
+      align: 'left'
+   },
+   {
+      propKey: 'seniority_level',
+      label: 'Seniority Level',
+      align: 'left'
+   },
+   {
+      propKey: 'employment_type',
+      label: 'Employment Type',
+      align: 'left'
+   },
+];

--- a/src/components/tables/OpportunitiesTable/OpportunitiesTable.tsx
+++ b/src/components/tables/OpportunitiesTable/OpportunitiesTable.tsx
@@ -15,7 +15,7 @@ export default function OpportunitiesTable({ where }: OpportunitiesTableProps): 
       if (isLoaded.current) return;
 
       isLoaded.current = true;
-      ajax.get<OpportunityData[]>('/opportunity/search').then((response) => {
+      ajax.get<OpportunityData[]>('/opportunity/search', { params: { where } }).then((response) => {
          if (response.error) {
             console.error('Error fetching opportunities:', response.message);
             return;
@@ -27,7 +27,7 @@ export default function OpportunitiesTable({ where }: OpportunitiesTableProps): 
       }).finally(() => {
          setIsLoading(false);
       });
-   }, []);
+   }, [ajax]);
 
    return (
       <TableBase<OpportunityData>

--- a/src/components/tables/OpportunitiesTable/OpportunitiesTable.tsx
+++ b/src/components/tables/OpportunitiesTable/OpportunitiesTable.tsx
@@ -1,0 +1,41 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { TableBase } from '@/components/common';
+import { opportunitiesTableConfig } from './OpportunitiesTable.config';
+import type { OpportunitiesTableProps } from './OpportunitiesTable.types';
+import type { OpportunityData } from '@/types/database.types';
+import { useAjax } from '@/hooks/useAjax';
+
+export default function OpportunitiesTable({ where }: OpportunitiesTableProps): React.JSX.Element {
+   const [ isLoading, setIsLoading ] = useState<boolean>(true);
+   const [ items, setItems ] = useState<OpportunityData[]>([]);
+   const isLoaded = useRef<boolean>(false);
+   const ajax = useAjax();
+
+   useEffect(() => {
+      if (isLoaded.current) return;
+
+      isLoaded.current = true;
+      ajax.get<OpportunityData[]>('/opportunity/search').then((response) => {
+         if (response.error) {
+            console.error('Error fetching opportunities:', response.message);
+            return;
+         }
+
+         setItems(response.data);
+      }).catch((error) => {
+         console.error('Error fetching opportunities:', error);
+      }).finally(() => {
+         setIsLoading(false);
+      });
+   }, []);
+
+   return (
+      <TableBase<OpportunityData>
+         className="OpportunitiesTable"
+         items={items}
+         columnConfig={opportunitiesTableConfig}
+         loading={isLoading}
+         noDocumentsText="No opportunities found"
+      />
+   );
+}

--- a/src/components/tables/OpportunitiesTable/OpportunitiesTable.tsx
+++ b/src/components/tables/OpportunitiesTable/OpportunitiesTable.tsx
@@ -27,7 +27,7 @@ export default function OpportunitiesTable({ where }: OpportunitiesTableProps): 
       }).finally(() => {
          setIsLoading(false);
       });
-   }, [ajax]);
+   }, [ajax, where]);
 
    return (
       <TableBase<OpportunityData>

--- a/src/components/tables/OpportunitiesTable/OpportunitiesTable.types.ts
+++ b/src/components/tables/OpportunitiesTable/OpportunitiesTable.types.ts
@@ -1,0 +1,3 @@
+export interface OpportunitiesTableProps {
+   where?: Record<string, unknown>;
+}

--- a/src/components/tables/index.tsx
+++ b/src/components/tables/index.tsx
@@ -1,0 +1,1 @@
+export { default as OpportunitiesTable } from './OpportunitiesTable/OpportunitiesTable';

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -12,6 +12,16 @@ export interface BasicData {
    tableName: string;
 }
 
+export interface OpportunityData extends BasicData {
+   job_title?: string;
+   job_description?: string;
+   location?: string;
+   seniority_level?: string;
+   employment_type?: string;
+   cv_id?: number;
+   company_id?: number;
+}
+
 export interface ExperienceData extends ExperienceSetData {
    company: CompanyData;
    company_id: number;


### PR DESCRIPTION
## [FRD-187] Description
This pull request introduces a new admin-facing "Opportunities" search and management page, along with the supporting table component and data types. The changes include the new page, table configuration, data fetching logic, and integration into the admin menu.

**Admin Opportunities Search Feature**

* Added a new page at `/admin/opportunity/search` that displays a searchable table of opportunities for admin users. [[1]](diffhunk://#diff-0ed37e0c773dcdfbcfb5e0cb42e8fbd6924d3165c81719b3c275e560c77425c9R1-R13) [[2]](diffhunk://#diff-04b4238fbc679ae3334d611152a9e9e5d7fe45e1b5dde4a72ae8e05003485a36R1-R20) [[3]](diffhunk://#diff-48b5d947341e52944e2f1e8469959b6915f5d27f73963741ec77d10391e63e96R1) [[4]](diffhunk://#diff-b3b13b666b2a346c6c14431a5ef51746297ffacec34c6470e072df6b78ddd717L36-R36)

**Opportunities Table Implementation**

* Implemented the `OpportunitiesTable` component with data fetching via AJAX, loading state management, and error handling. [[1]](diffhunk://#diff-242b3325d2ed091c4e5575852d6f68b3d0f2ed413e67e4a65eba44824c8d58e8R1-R41) [[2]](diffhunk://#diff-ee5eabb6ec74921523132ba1bdfd57ef3054af9df629477f1319620a11bcc24bR1-R3)
* Defined the table column configuration in `OpportunitiesTable.config.ts` to display opportunity attributes such as ID, Job Title, Seniority Level, and Employment Type.
* Exported the new table component in the shared tables index for reuse.

**Data Model Updates**

* Extended the `OpportunityData` interface in `database.types.ts` to include relevant fields for opportunities, such as job title, description, seniority level, and related IDs.

[FRD-187]: https://feliperamosdev.atlassian.net/browse/FRD-187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ