### PR TITLE
[FRD-189] Opportunity Modal

### DIFF
--- a/src/components/common/FlexLine/FlexLine.module.scss
+++ b/src/components/common/FlexLine/FlexLine.module.scss
@@ -10,6 +10,10 @@
       flex-direction: row;
    }
 
+   &:not(:last-child) {
+      margin-bottom: 0.5rem;
+   }
+
    > div:nth-child(1),
    > div:nth-child(2) {
       flex: 1;

--- a/src/components/common/ModalBase/ModalBase.types.ts
+++ b/src/components/common/ModalBase/ModalBase.types.ts
@@ -1,7 +1,7 @@
 import { SizeKeyword } from "@/helpers/parse.helpers";
 
 export interface ModalBaseProps {
-   title?: string;
+   title?: string | React.ReactNode;
    icon?: React.ReactNode;
    className?: string | string[];
    elevation?: SizeKeyword;

--- a/src/components/forms/opportunities/BuildOpportunityForm/components/GenerateSummary.tsx
+++ b/src/components/forms/opportunities/BuildOpportunityForm/components/GenerateSummary.tsx
@@ -1,6 +1,6 @@
 import { Card } from '@/components/common';
 import { WidgetHeader } from '@/components/headers';
-import LoadingModal from '@/components/modals/LoadingModal/LoadingModal';
+import { LoadingModal } from '@/components/modals';
 import { loadUserCVs } from '@/helpers/database.helpers';
 import { FormInput, FormSelect } from '@/hooks';
 import { useForm } from '@/hooks/Form/Form';

--- a/src/components/modals/OpportunityModal/OpportunityModal.tsx
+++ b/src/components/modals/OpportunityModal/OpportunityModal.tsx
@@ -1,0 +1,74 @@
+import { Card, DateView, FlexLine, Markdown, ModalBase } from "@/components/common";
+import { OpportunityModalProps } from "./OpportunityModal.types";
+import { ContentSidebar, DataContainer } from "@/components/layout";
+import { Fragment } from "react";
+import { WidgetHeader } from "@/components/headers";
+import { RequestQuote } from "@mui/icons-material";
+
+export default function OpportunityModal({ isOpen, onClose, data }: OpportunityModalProps) {
+   if (!data) return null;
+   return (
+      <ModalBase
+         isOpen={isOpen}
+         onClose={onClose}
+         title={<><RequestQuote /> Opportunity Details</>}
+         widthSize="xl"
+      >
+         <ContentSidebar>
+            <Fragment>
+               <Card>
+                  <DataContainer>
+                     <label>Job Title</label>
+                     <p>{data.job_title}</p>
+                  </DataContainer>
+                  <DataContainer>
+                     <label>Job URL</label>
+                     <p>{data.job_url || '---'}</p>
+                  </DataContainer>
+               </Card>
+               <Card>
+                  <FlexLine>
+                     <DataContainer vertical>
+                        <label>Created At</label>
+                        <DateView date={data.created_at || '---'} />
+                     </DataContainer>
+                     <DataContainer vertical>
+                        <label>Location</label>
+                        <p>{data.location || '---'}</p>
+                     </DataContainer>
+                  </FlexLine>
+
+                  <FlexLine>
+                     <DataContainer vertical>
+                        <label>Employment Type</label>
+                        <p>{data.employment_type || '---'}</p>
+                     </DataContainer>
+                     <DataContainer vertical>
+                        <label>Seniority Level</label>
+                        <p>{data.seniority_level || '---'}</p>
+                     </DataContainer>
+                  </FlexLine>
+               </Card>
+
+               <Card>
+                  <DataContainer vertical>
+                     <label>Job Description</label>
+                     <Markdown value={data.job_description || '---'} />
+                  </DataContainer>
+               </Card>
+            </Fragment>
+
+            <Fragment>
+               <Card>
+                  <WidgetHeader title="Cover Letter" />
+               </Card>
+               <Card>
+                  <WidgetHeader title="Custom CV" />
+
+                  {data.relatedCV?.title}
+               </Card>
+            </Fragment>
+         </ContentSidebar>
+      </ModalBase>
+   );
+}

--- a/src/components/modals/OpportunityModal/OpportunityModal.types.ts
+++ b/src/components/modals/OpportunityModal/OpportunityModal.types.ts
@@ -1,0 +1,8 @@
+import { SizeKeyword } from "@/helpers/parse.helpers";
+import { OpportunityData } from "@/types/database.types";
+
+export interface OpportunityModalProps {
+   isOpen: boolean;
+   onClose: () => void;
+   data: OpportunityData | null;
+}

--- a/src/components/modals/OpportunityModal/OpportunityModal.types.ts
+++ b/src/components/modals/OpportunityModal/OpportunityModal.types.ts
@@ -1,5 +1,4 @@
-import { SizeKeyword } from "@/helpers/parse.helpers";
-import { OpportunityData } from "@/types/database.types";
+import { OpportunityData } from '@/types/database.types';
 
 export interface OpportunityModalProps {
    isOpen: boolean;

--- a/src/components/modals/index.tsx
+++ b/src/components/modals/index.tsx
@@ -1,1 +1,3 @@
 export { default as GenerateCustomCVModal } from './GenerateCustomCVModal/GenerateCustomCVModal';
+export { default as LoadingModal } from './LoadingModal/LoadingModal';
+export { default as OpportunityModal } from './OpportunityModal/OpportunityModal';

--- a/src/components/tables/OpportunitiesTable/OpportunitiesTable.tsx
+++ b/src/components/tables/OpportunitiesTable/OpportunitiesTable.tsx
@@ -1,21 +1,26 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { TableBase } from '@/components/common';
 import { opportunitiesTableConfig } from './OpportunitiesTable.config';
+import { OpportunityModal } from '@/components/modals';
+import { useAjax } from '@/hooks/useAjax';
+
+// Types
 import type { OpportunitiesTableProps } from './OpportunitiesTable.types';
 import type { OpportunityData } from '@/types/database.types';
-import { useAjax } from '@/hooks/useAjax';
 
 export default function OpportunitiesTable({ where, sort, order }: OpportunitiesTableProps): React.JSX.Element {
    const [ isLoading, setIsLoading ] = useState<boolean>(true);
    const [ items, setItems ] = useState<OpportunityData[]>([]);
+   const [ modalData, setModalData ] = useState<OpportunityData | null>(null);
    const isLoaded = useRef<boolean>(false);
    const ajax = useAjax();
 
    useEffect(() => {
       if (isLoaded.current) return;
+      
+      isLoaded.current = true;
       let whereString: string | undefined;
 
-      isLoaded.current = true;
       try {
          whereString = JSON.stringify(where || {});
       } catch (error) {
@@ -37,13 +42,20 @@ export default function OpportunitiesTable({ where, sort, order }: Opportunities
       });
    }, [ ajax, where, sort, order ]);
 
-   return (
+   return (<>
       <TableBase<OpportunityData>
          className="OpportunitiesTable"
          items={items}
          columnConfig={opportunitiesTableConfig}
          loading={isLoading}
          noDocumentsText="No opportunities found"
+         onClickRow={(item) => setModalData(item)}
       />
-   );
+
+      <OpportunityModal
+         isOpen={!!modalData}
+         onClose={() => setModalData(null)}
+         data={modalData}
+      />
+   </>);
 }


### PR DESCRIPTION
## [FRD-189] Description
This pull request introduces a modal for viewing detailed information about an opportunity from the Opportunities Table, along with some related UI and type improvements. The key changes include implementing the new `OpportunityModal` component, integrating it into the Opportunities Table, and making some minor enhancements and refactors to modal and layout components.

**Opportunity Modal Implementation and Integration:**

- Added a new `OpportunityModal` component that displays detailed information about an opportunity, including job details, description, cover letter, and related CV, using a modal dialog (`OpportunityModal.tsx`, `OpportunityModal.types.ts`). [[1]](diffhunk://#diff-8e5ad54c4b65cc84e0f29da015e8ccb465cbe7145e8dcf857e7577d88fe71ffcR1-R74) [[2]](diffhunk://#diff-398c1aaa2cbcb997b3f2cf173ad942ec98e87148a063851d69d399e39e3cb00fR1-R8)
- Integrated the `OpportunityModal` into the `OpportunitiesTable` so that clicking a row opens the modal with the selected opportunity's details (`OpportunitiesTable.tsx`). [[1]](diffhunk://#diff-242b3325d2ed091c4e5575852d6f68b3d0f2ed413e67e4a65eba44824c8d58e8R4-R23) [[2]](diffhunk://#diff-242b3325d2ed091c4e5575852d6f68b3d0f2ed413e67e4a65eba44824c8d58e8L40-R60)

**Modal and Component Refactors:**

- Updated the modal exports to include `OpportunityModal` and `LoadingModal` for easier imports (`modals/index.tsx`).
- Changed the import of `LoadingModal` in the opportunity form generator to use the new export (`GenerateSummary.tsx`).
- Enhanced the `ModalBase` type to allow the `title` prop to accept a `ReactNode` (for richer titles with icons, etc.) (`ModalBase.types.ts`).

**UI/Styling Improvements:**

- Adjusted `FlexLine` styles to add spacing between lines for improved layout in modals and other components (`FlexLine.module.scss`).

[FRD-189]: https://feliperamosdev.atlassian.net/browse/FRD-189?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ