### PR TITLE
[FRD-196] CV Download on Opportunities Modal

### DIFF
--- a/src/components/modals/OpportunityModal/OpportunityModal.module.scss
+++ b/src/components/modals/OpportunityModal/OpportunityModal.module.scss
@@ -1,0 +1,11 @@
+.OpportunityModal {
+   .cvLinks {
+      display: flex;
+      gap: 1rem;
+      margin-bottom: 1rem;
+
+      .button {
+         flex: 1;
+      }
+   }
+}

--- a/src/components/modals/OpportunityModal/OpportunityModal.tsx
+++ b/src/components/modals/OpportunityModal/OpportunityModal.tsx
@@ -1,14 +1,28 @@
-import { Card, DateView, FlexLine, Markdown, ModalBase } from "@/components/common";
-import { OpportunityModalProps } from "./OpportunityModal.types";
-import { ContentSidebar, DataContainer } from "@/components/layout";
-import { Fragment } from "react";
-import { WidgetHeader } from "@/components/headers";
-import { RequestQuote } from "@mui/icons-material";
+import { Card, DateView, FlexLine, Markdown, ModalBase } from '@/components/common';
+import { OpportunityModalProps } from './OpportunityModal.types';
+import { ContentSidebar, DataContainer } from '@/components/layout';
+import { Fragment } from 'react';
+import { WidgetHeader } from '@/components/headers';
+import { RequestQuote } from '@mui/icons-material';
+import { cvPDFDownloadLink } from '@/helpers/app.helpers';
+import { Button } from '@mui/material';
+import Link from 'next/link';
+import { allowedLanguages, languageNames } from '@/app.config';
+import { CVData } from '@/types/database.types';
+import styles from './OpportunityModal.module.scss';
+import { CVTile } from '@/components/tiles';
+import { useRouter } from 'next/navigation';
 
 export default function OpportunityModal({ isOpen, onClose, data }: OpportunityModalProps) {
-   if (!data) return null;
+   const router = useRouter();
+
+   if (!data) {
+      return null;
+   }
+
    return (
       <ModalBase
+         className={styles.OpportunityModal}
          isOpen={isOpen}
          onClose={onClose}
          title={<><RequestQuote /> Opportunity Details</>}
@@ -65,7 +79,26 @@ export default function OpportunityModal({ isOpen, onClose, data }: OpportunityM
                <Card>
                   <WidgetHeader title="Custom CV" />
 
-                  {data.relatedCV?.title}
+                  {data.relatedCV ? (<>
+                     <div className={styles.cvLinks}>
+                        {allowedLanguages.map(lang => (
+                           <Button
+                              key={lang}
+                              LinkComponent={Link}
+                              className={styles.button}
+                              href={cvPDFDownloadLink(data.relatedCV as CVData, lang)}
+                              target="_blank" rel="noopener noreferrer"
+                           >
+                              {languageNames[lang] || lang.toUpperCase()}
+                           </Button>
+                        ))}
+                     </div>
+
+                     <CVTile cv={data.relatedCV} onClick={() => router.push(`/admin/curriculum/${data.relatedCV?.id}`)} />
+                  </>) : (
+                     <p>No CV attached.</p>
+                  )}
+
                </Card>
             </Fragment>
          </ContentSidebar>

--- a/src/components/modals/OpportunityModal/OpportunityModal.tsx
+++ b/src/components/modals/OpportunityModal/OpportunityModal.tsx
@@ -8,13 +8,13 @@ import { cvPDFDownloadLink } from '@/helpers/app.helpers';
 import { Button } from '@mui/material';
 import Link from 'next/link';
 import { allowedLanguages, languageNames } from '@/app.config';
-import { CVData } from '@/types/database.types';
 import styles from './OpportunityModal.module.scss';
 import { CVTile } from '@/components/tiles';
 import { useRouter } from 'next/navigation';
 
 export default function OpportunityModal({ isOpen, onClose, data }: OpportunityModalProps) {
    const router = useRouter();
+   const isCVExists = data?.relatedCV && data.relatedCV !== null;
 
    if (!data) {
       return null;
@@ -79,15 +79,16 @@ export default function OpportunityModal({ isOpen, onClose, data }: OpportunityM
                <Card>
                   <WidgetHeader title="Custom CV" />
 
-                  {data.relatedCV ? (<>
+                  {isCVExists ? (<>
                      <div className={styles.cvLinks}>
                         {allowedLanguages.map(lang => (
                            <Button
                               key={lang}
                               LinkComponent={Link}
                               className={styles.button}
-                              href={cvPDFDownloadLink(data.relatedCV as CVData, lang)}
-                              target="_blank" rel="noopener noreferrer"
+                              href={cvPDFDownloadLink(data.relatedCV, lang)}
+                              rel="noopener noreferrer"
+                              target="_blank"
                            >
                               {languageNames[lang] || lang.toUpperCase()}
                            </Button>

--- a/src/components/tiles/CVTile/CVTile.tsx
+++ b/src/components/tiles/CVTile/CVTile.tsx
@@ -10,15 +10,15 @@ export default function CVTile({ className, cv, onClick = () => {} }: CVTileProp
       styles.CVTile
    ]);
 
+   if (!cv || cv === null) {
+      return null;
+   }
+
    const summary = cv?.summary && cv.summary.length > 200 ? (
       `${cv.summary.substring(0, 200)}...`
    ) : (
       cv?.summary || ''
    )
-
-   if (!cv || cv === null) {
-      return null;
-   }
 
    return (
       <Card className={CSS} padding="s" onClick={() => onClick(cv.id)}>

--- a/src/components/tiles/CVTile/CVTile.types.ts
+++ b/src/components/tiles/CVTile/CVTile.types.ts
@@ -2,6 +2,6 @@ import { CVData } from "@/types/database.types";
 
 export interface CVTileProps {
    className?: string | string[];
-   cv: CVData;
+   cv?: CVData;
    onClick?: (cvId: number) => void;
 }

--- a/src/helpers/app.helpers.ts
+++ b/src/helpers/app.helpers.ts
@@ -26,7 +26,11 @@ export function apiURL(path: string, queryParams?: Record<string, string>): stri
    return url.toString();
 }
 
-export function cvPDFDownloadLink(cv: CVData, locale: string = defaultLanguage): string {
+export function cvPDFDownloadLink(cv?: CVData | null, locale: string = defaultLanguage): string {
+   if (!cv) {
+      throw new Error('CV data is required to generate the PDF link');
+   }
+
    const cvId = cv.id;
    const userFullName = cv.user?.name?.replace(/ /g, '_');
 

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -21,7 +21,7 @@ export interface OpportunityData extends BasicData {
    employment_type?: string;
    cv_id?: number;
    company_id?: number;
-   relatedCV?: CVData | null;
+   relatedCV?: CVData;
    company?: CompanyData | null;
    opportunity_user_id: number;
 }


### PR DESCRIPTION
## [FRD-196] Description
This pull request enhances the `OpportunityModal` component by adding a section for displaying and downloading related CVs in multiple languages, along with improvements to the modal's structure and styling. The most important changes are grouped below:

**Feature: Multi-language CV download and display**

* Added a section to the modal that shows download buttons for each allowed CV language, generating links dynamically using `cvPDFDownloadLink`. The language names are displayed on the buttons, and the links open the corresponding PDF in a new tab.
* Integrated the `CVTile` component to display a summary of the related CV, with navigation to the CV's admin page on click.

**Styling improvements**

* Introduced new styles in `OpportunityModal.module.scss` to layout the CV download buttons in a horizontal flex row with spacing and consistent button sizing.
* Applied the new `OpportunityModal` class to the modal for scoping the added styles.

**Code organization and imports**

* Added and reorganized imports for helpers, config, types, styles, and components needed for the new CV-related functionality.

[FRD-196]: https://feliperamosdev.atlassian.net/browse/FRD-196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ