### PR TITLE
[FRD-192] Cover Letters Search Page

### DIFF
--- a/src/app/admin/cover-letter/search/page.tsx
+++ b/src/app/admin/cover-letter/search/page.tsx
@@ -1,0 +1,13 @@
+import { CoverLetterSearch } from '@/components/content/admin/cover-letter';
+import { AdminPageBase } from '@/components/layout';
+import { headersAcceptLanguage } from '@/helpers';
+
+export default async function CoverLetterSearchPage() {
+   const locale = await headersAcceptLanguage();
+
+   return (
+      <AdminPageBase language={locale}>
+         <CoverLetterSearch />
+      </AdminPageBase>
+   );
+}

--- a/src/components/content/admin/cover-letter/CoverLetterSearch/CoverLetterSearch.tsx
+++ b/src/components/content/admin/cover-letter/CoverLetterSearch/CoverLetterSearch.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { RoundButton } from '@/components/buttons';
+import { Container } from '@/components/common';
+import { PageHeader } from '@/components/headers';
+import CoverLettersTable from '@/components/tables/CoverLettersTable/CoverLettersTable';
+import { Add } from '@mui/icons-material';
+import Link from 'next/link';
+
+export default function CoverLetterSearch() {
+   return (
+      <div className="CoverLetterSearch">
+         <PageHeader
+            title="Cover Letters"
+            description="Manage and review cover letters submitted by users."
+         >
+            <RoundButton
+               LinkComponent={Link}
+               color="tertiary"
+               title="Add New Cover Letter"
+               href="/admin/cover-letters/create"
+            >
+               <Add />
+            </RoundButton>
+         </PageHeader>
+
+         <Container fullwidth>
+            <CoverLettersTable />
+         </Container>
+      </div>
+   );
+} 

--- a/src/components/content/admin/cover-letter/CoverLetterSearch/CoverLetterSearch.tsx
+++ b/src/components/content/admin/cover-letter/CoverLetterSearch/CoverLetterSearch.tsx
@@ -18,7 +18,7 @@ export default function CoverLetterSearch() {
                LinkComponent={Link}
                color="tertiary"
                title="Add New Cover Letter"
-               href="/admin/cover-letters/create"
+               href="/admin/cover-letter/create"
             >
                <Add />
             </RoundButton>

--- a/src/components/content/admin/cover-letter/index.tsx
+++ b/src/components/content/admin/cover-letter/index.tsx
@@ -1,0 +1,1 @@
+export { default as CoverLetterSearch } from './CoverLetterSearch/CoverLetterSearch';

--- a/src/components/menus/AdminMenu/AdminMenu.tsx
+++ b/src/components/menus/AdminMenu/AdminMenu.tsx
@@ -12,7 +12,8 @@ import {
    Store,
    DownhillSkiing,
    School,
-   Language
+   Language,
+   MarkAsUnread
 } from '@mui/icons-material';
 
 const MENU_ITEMS: MenuItem[] = [
@@ -25,6 +26,11 @@ const MENU_ITEMS: MenuItem[] = [
       label: 'Curriculums',
       href: '/admin/curriculums',
       icon: <PictureAsPdf />,
+   },
+   {
+      label: 'Cover Letters',
+      href: '/admin/cover-letter/search',
+      icon: <MarkAsUnread />,
    },
    {
       label: 'Experiences',

--- a/src/components/tables/CoverLettersTable/CoverLettersTable.tsx
+++ b/src/components/tables/CoverLettersTable/CoverLettersTable.tsx
@@ -1,0 +1,16 @@
+import { TableBase } from "@/components/common";
+
+export default function CoverLettersTable() {
+   return (
+      <TableBase
+         items={[]}
+         loading={false}
+         columnConfig={[
+            { propKey: 'id', label: 'ID' },
+            { propKey: 'subject', label: 'Subject' },
+            { propKey: 'from_id', label: 'From ID' },
+            { propKey: 'company_id', label: 'Company ID' }
+         ]}
+      />
+   );
+}


### PR DESCRIPTION
## [FRD-192] Description
This pull request introduces a new admin page for searching and managing cover letters, integrates it into the admin navigation menu, and adds a placeholder table for displaying cover letter data. The changes are primarily focused on expanding admin functionality and improving navigation.

**Admin cover letter management feature:**

* Added a new `CoverLetterSearchPage` at `/admin/cover-letter/search`, which renders the `CoverLetterSearch` component within the admin layout and uses the user's locale.
* Implemented the `CoverLetterSearch` component, including a page header, "Add New Cover Letter" button, and a table for cover letter data.
* Exported `CoverLetterSearch` from the admin cover letter components index for easier imports.
* Added a new `CoverLettersTable` component as a placeholder to display cover letter information in a tabular format.

**Navigation updates:**

* Added a "Cover Letters" entry to the admin menu, linking to the new search page and using the `MarkAsUnread` icon. [[1]](diffhunk://#diff-b3b13b666b2a346c6c14431a5ef51746297ffacec34c6470e072df6b78ddd717L15-R16) [[2]](diffhunk://#diff-b3b13b666b2a346c6c14431a5ef51746297ffacec34c6470e072df6b78ddd717R30-R34)

[FRD-192]: https://feliperamosdev.atlassian.net/browse/FRD-192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ