### PR TITLE
[FRD-193] Read and Edit Cover Letter Modal

### DIFF
--- a/src/components/common/Card/Card.scss
+++ b/src/components/common/Card/Card.scss
@@ -2,4 +2,5 @@
 
 .Card {
    margin-bottom: 1rem;
+   outline: none;
 }

--- a/src/components/forms/cover-letter/BuildCoverLetterForm/BuildCoverLetterForm.tsx
+++ b/src/components/forms/cover-letter/BuildCoverLetterForm/BuildCoverLetterForm.tsx
@@ -1,14 +1,15 @@
-import { Form, FormInput, FormSubmit } from '@/hooks';
+import { Form, FormInput, FormSubmit, useLetters } from '@/hooks';
 import { BuildCoverLetterFormProps } from './BuildCoverLetterForm.types';
 import { FlexLine } from '@/components/common';
 import { Button } from '@mui/material';
 import { LetterData } from '@/types/database.types';
-import { useAjax } from '@/hooks/useAjax';
 
 export default function BuildCoverLetterForm({ initialValues, opportunityId, companyId, onSuccess = () => {} }: BuildCoverLetterFormProps) {
-   const ajax = useAjax();
+   const { createLetter } = useLetters();
 
    const handleSubmit = async (values: Partial<LetterData>) => {
+      values.type = 'cover-letter';
+
       if (opportunityId) {
          values.opportunity_id = opportunityId;
       }
@@ -18,13 +19,8 @@ export default function BuildCoverLetterForm({ initialValues, opportunityId, com
       }
 
       try {
-         const created = await ajax.post<LetterData>('/cover-letter/create', values);
-
-         if (created.error) {
-            throw new Error(created.message);
-         }
-
-         onSuccess(created.data as LetterData);
+         const created = await createLetter(values);
+         onSuccess(created);
          return created;
       } catch (error) {
          return error;

--- a/src/components/forms/cover-letter/EditLetterForm/EditLetterForm.tsx
+++ b/src/components/forms/cover-letter/EditLetterForm/EditLetterForm.tsx
@@ -1,0 +1,68 @@
+import { Form, FormInput, FormSelect, FormSubmit } from '@/hooks';
+import { LetterData } from '@/types/database.types';
+import { EditLetterFormProps } from './EditLetterForm.types';
+import { ContentSidebar } from '@/components/layout';
+import { Fragment } from 'react';
+import { loadCompaniesOptions } from '@/helpers/database.helpers';
+import { useAjax } from '@/hooks/useAjax';
+import { useTextResources } from '@/services/TextResources/TextResourcesProvider';
+import { Card } from '@/components/common';
+import { CardProps } from '@/components/common/Card/Card.types';
+
+export default function EditLetterForm({ letter, updateLetter }: EditLetterFormProps) {
+   const { textResources } = useTextResources();
+   const ajax = useAjax();
+   const cardProps: CardProps = { padding: 'm' };
+
+   const handleSubmit = async (data: Partial<LetterData>) => {
+      if (!letter?.id) {
+         throw new Error('Letter ID is required for updating');
+      }
+
+      try {
+         const updated = await updateLetter(letter.id, data);
+         return updated;
+      } catch (error) {
+         return error;
+      }
+   }
+
+   return (
+      <Form<LetterData>
+         initialValues={letter}
+         onSubmit={handleSubmit}
+         editMode
+         hideSubmit
+      >
+         <ContentSidebar>
+            <Card {...cardProps}>
+               <FormInput
+                  fieldName="subject"
+                  label="Subject"
+                  placeholder="Enter the subject"
+               />
+               <FormInput
+                  fieldName="body"
+                  label="Body"
+                  placeholder="Enter the body"
+                  multiline
+               />
+            </Card>
+
+            <Fragment>
+               <Card {...cardProps}>
+                  <FormSelect
+                     fieldName="company_id"
+                     label="Company"
+                     loadOptions={() => loadCompaniesOptions(ajax, textResources)}
+                  />
+               </Card>
+
+               <Card {...cardProps}>
+                  <FormSubmit label="Save Changes" />
+               </Card>
+            </Fragment>
+         </ContentSidebar>
+      </Form>
+   );
+}

--- a/src/components/forms/cover-letter/EditLetterForm/EditLetterForm.types.ts
+++ b/src/components/forms/cover-letter/EditLetterForm/EditLetterForm.types.ts
@@ -1,0 +1,6 @@
+import { LetterData } from "@/types/database.types";
+
+export interface EditLetterFormProps {
+   letter: Partial<LetterData>;
+   updateLetter: (id: number, data: Partial<LetterData>) => Promise<LetterData | Error>;
+}

--- a/src/components/forms/index.tsx
+++ b/src/components/forms/index.tsx
@@ -5,3 +5,4 @@ export { default as CreateSkillForm } from './skills/CreateSkillForm/CreateSkill
 export { default as EditExperienceDetailsForm } from './experiences/EditExperienceDetails/EditExperienceDetails';
 export { default as EditExperienceSetForm } from './experiences/EditExperienceSetForm/EditExperienceSetForm';
 export { default as EditExperienceSkillsForm } from './experiences/EditExperienceSkills/EditExperienceSkills';
+export { default as EditCoverLetterForm } from './cover-letter/EditLetterForm/EditLetterForm';

--- a/src/components/forms/opportunities/BuildOpportunityForm/BuildOpportunityForm.tsx
+++ b/src/components/forms/opportunities/BuildOpportunityForm/BuildOpportunityForm.tsx
@@ -1,44 +1,27 @@
-import { Form } from '@/hooks';
+import { Form, useOpportunities } from '@/hooks';
 import LinkedInScrap from './components/LinkedInScrap';
 import JobDetails from './components/JobDetails';
 import GenerateSummary from './components/GenerateSummary';
-import { FormValues } from '@/hooks/Form/Form.types';
-import { useAjax } from '@/hooks/useAjax';
-import { OpportunityData } from '@/types/database.types';
 import { useRouter } from 'next/navigation';
+import { OpportunityCreateParams } from '@/hooks/useOpportinities/useOpportunities.types';
 
 export default function BuildOpportunityForm() {
-   const ajax = useAjax();
+   const { createOpportunity } = useOpportunities();
    const router = useRouter();
 
-   const createOpportunity = async (values: FormValues) => {
+   const create = async (values: Partial<OpportunityCreateParams>) => {
       try {
-         const created = await ajax.post<OpportunityData>('/opportunity/create', {
-            jobURL: values.jobURL,
-            jobTitle: values.jobTitle,
-            jobDescription: values.jobDescription,
-            jobLocation: values.jobLocation,
-            jobSeniority: values.jobSeniority,
-            jobEmploymentType: values.jobEmploymentType,
-            companyName: values.jobCompany,
-            cvSummary: values.currentInput,
-            cvTemplate: values.cvTemplate
-         });
+         const created = await createOpportunity(values);
 
-         if (created.error) {
-            return created;
-         }
-
-         router.push(`/admin/opportunity/search`);
+         router.push(`/admin/opportunity/search?opportunity_id=${created.id}`);
          return created;
       } catch (error) {
-         console.error('Error creating opportunity:', error);
          return error;
       }
    }
 
    return (<>
-      <Form onSubmit={createOpportunity}>
+      <Form<OpportunityCreateParams> onSubmit={create}>
          <LinkedInScrap />
          <JobDetails />
          <GenerateSummary />

--- a/src/components/forms/opportunities/BuildOpportunityForm/components/GenerateSummary.tsx
+++ b/src/components/forms/opportunities/BuildOpportunityForm/components/GenerateSummary.tsx
@@ -17,7 +17,7 @@ export default function GenerateSummary() {
    const { textResources } = useTextResources();
    const ajax = useAjax();
 
-   const currentInput = getValue('currentInput');
+   const currentInput = getValue('cvSummary');
    const customPrompt = getValue('customPrompt');
    const jobDescription = getValue('jobDescription');
    const aiThread = getValue('aiThread');
@@ -54,7 +54,7 @@ export default function GenerateSummary() {
          }
 
          setFieldValue('customPrompt', '');
-         setFieldValue('currentInput', summary);
+         setFieldValue('cvSummary', summary);
          setFieldValue('aiThread', aiThread);
       });
    };
@@ -87,7 +87,7 @@ export default function GenerateSummary() {
 
          {currentInput ? (
             <FormInput
-               fieldName="currentInput"
+               fieldName="cvSummary"
                label="CV Summary"
                minRows={5}
                multiline

--- a/src/components/forms/opportunities/BuildOpportunityForm/components/LinkedInScrap.tsx
+++ b/src/components/forms/opportunities/BuildOpportunityForm/components/LinkedInScrap.tsx
@@ -54,7 +54,7 @@ export default function LinkedInScrap() {
 
          setFieldValue('jobURL', jobURL);
          setFieldValue('jobTitle', jobTitle);
-         setFieldValue('jobCompany', jobCompany);
+         setFieldValue('companyName', jobCompany);
          setFieldValue('jobDescription', jobDescription);
          setFieldValue('jobLocation', jobLocation);
          setFieldValue('jobSeniority', jobSeniority);

--- a/src/components/forms/opportunities/EditOpportunityForm/EditOpportunityForm.tsx
+++ b/src/components/forms/opportunities/EditOpportunityForm/EditOpportunityForm.tsx
@@ -4,22 +4,15 @@ import { CardProps } from '@/components/common/Card/Card.types';
 import { Form, FormInput } from '@/hooks';
 import { EditOpportunityFormProps } from './EditOpportunityForm.types';
 import { OpportunityData } from '@/types/database.types';
-import { useAjax } from '@/hooks/useAjax';
 
-export default function EditOpportunityForm({ opportunity, updateData = () => {} }: EditOpportunityFormProps): JSX.Element {
-   const ajax = useAjax();
+export default function EditOpportunityForm({ opportunity, updateData }: EditOpportunityFormProps): JSX.Element {
    const cardProps: CardProps = { padding: 'm' };
 
    const handleSubmit = async (data: Partial<OpportunityData>) => {
-      try {
-         const updated = await ajax.patch<OpportunityData>('/opportunity/update', { id: opportunity.id, updates: data });
-         
-         if (updated.error) {
-            return updated;
-         }
+      if (!updateData) return;
 
-         updateData(updated.data);
-         return updated;
+      try {
+         return await updateData(opportunity.id, data);
       } catch (error) {
          return error;
       }

--- a/src/components/forms/opportunities/EditOpportunityForm/EditOpportunityForm.types.ts
+++ b/src/components/forms/opportunities/EditOpportunityForm/EditOpportunityForm.types.ts
@@ -2,5 +2,5 @@ import { OpportunityData } from "@/types/database.types";
 
 export interface EditOpportunityFormProps {
    opportunity: OpportunityData;
-   updateData: (newData: OpportunityData) => void;
+   updateData: (id: number, data: Partial<OpportunityData>) => Promise<OpportunityData>;
 }

--- a/src/components/headers/OpportunityHeader/OpportunityHeader.tsx
+++ b/src/components/headers/OpportunityHeader/OpportunityHeader.tsx
@@ -3,30 +3,23 @@ import { OpportunityHeaderProps } from './OpportunityHeader.types';
 import { Cancel, Delete, Edit } from '@mui/icons-material';
 import styles from './OpportunityHeader.module.scss';
 import Link from 'next/link';
-import { useAjax } from '@/hooks/useAjax';
+import { useOpportunities } from '@/hooks';
 
 export default function OpportunityHeader({ company, opportunityId, jobTitle, editMode = false, setEditMode = () => {} }: OpportunityHeaderProps) {
-   const ajax = useAjax();
    const setEdit = () => setEditMode(true);
    const cancelEdit = () => setEditMode(false);
+   const { deleteOpportunity } = useOpportunities();
 
    const handleDelete = async () => {
       if (!opportunityId) {
          return;
       }
 
-      const confirmDelete = confirm('Are you sure you want to delete this opportunity? This action cannot be undone.');
-      if (!confirmDelete) {
-         return;
-      }
-
-      const deleteRelated = confirm('Also delete related data?');
-
       try {
-         const deleted = await ajax.delete(`/opportunity/delete`, { data: { id: opportunityId, deleteRelated } });
+         const deleted = await deleteOpportunity(opportunityId);
 
-         if (deleted.error) {
-            return deleted;
+         if (!deleted?.success) {
+            throw deleted;
          }
 
          window.location.reload();

--- a/src/components/modals/BuildCoverLetterModal/BuildCoverLetterModal.tsx
+++ b/src/components/modals/BuildCoverLetterModal/BuildCoverLetterModal.tsx
@@ -52,7 +52,7 @@ export default function BuildCoverLetterModal({ isOpen = false, onClose, opportu
                   initialValues={initLetter}
                   opportunityId={opportunityId}
                   companyId={companyId}
-                  onSuccess={(newData) => {
+                  onSuccess={() => {
                      onClose();
                      setInitLetter(null);
                   }}

--- a/src/components/modals/BuildCoverLetterModal/BuildCoverLetterModal.tsx
+++ b/src/components/modals/BuildCoverLetterModal/BuildCoverLetterModal.tsx
@@ -1,13 +1,13 @@
 import { useEffect, useState, useCallback } from 'react';
 import { ModalBase, Spinner } from '@/components/common';
 import { BuildCoverLetterForm } from '@/components/forms/cover-letter';
-import { CoverLetterModalProps, CoverLetterResponse, GenerateCoverLetterStatus } from './CoverLetterModal.types';
+import { BuildCoverLetterModalProps, BuildCoverLetterResponse, GenerateCoverLetterStatus } from './BuildCoverLetterModal.types';
 import { useSocket } from '@/services/SocketClient';
 import { useTextResources } from '@/services/TextResources/TextResourcesProvider';
 import statusFeedback from '@/resources/text/feedback.text';
 import { LetterData } from '@/types/database.types';
 
-export default function CoverLetterModal({ isOpen = false, onClose, onSuccess, opportunityId, companyId }: CoverLetterModalProps) {
+export default function BuildCoverLetterModal({ isOpen = false, onClose, opportunityId, companyId }: BuildCoverLetterModalProps) {
    const [ initLetter, setInitLetter ] = useState<Partial<LetterData> | null>(null);
    const { isConnected, emit } = useSocket();
    const [ generateStatus, setGenerateStatus ] = useState<GenerateCoverLetterStatus>('starting');
@@ -18,7 +18,7 @@ export default function CoverLetterModal({ isOpen = false, onClose, onSuccess, o
 
       try {
          emit('generate-letter', { opportunityId }, (response) => {
-            const { letterSubject, letterBody } = response as CoverLetterResponse;
+            const { letterSubject, letterBody } = response as BuildCoverLetterResponse;
 
             setGenerateStatus('success');
             setInitLetter({
@@ -53,7 +53,6 @@ export default function CoverLetterModal({ isOpen = false, onClose, onSuccess, o
                   opportunityId={opportunityId}
                   companyId={companyId}
                   onSuccess={(newData) => {
-                     onSuccess(newData);
                      onClose();
                      setInitLetter(null);
                   }}

--- a/src/components/modals/BuildCoverLetterModal/BuildCoverLetterModal.types.ts
+++ b/src/components/modals/BuildCoverLetterModal/BuildCoverLetterModal.types.ts
@@ -1,16 +1,13 @@
-import { LetterData } from "@/types/database.types";
-
 export type GenerateCoverLetterStatus = 'starting' | 'generating' | 'success' | 'error';
 
-export interface CoverLetterModalProps {
+export interface BuildCoverLetterModalProps {
    isOpen: boolean;
    onClose: () => void;
-   onSuccess: (newData: LetterData) => void;
    opportunityId: number;
    companyId?: number;
 }
 
-export interface CoverLetterResponse {
+export interface BuildCoverLetterResponse {
    letterSubject: string;
    letterBody: string;
 }

--- a/src/components/modals/LetterModal/LetterModal.tsx
+++ b/src/components/modals/LetterModal/LetterModal.tsx
@@ -1,0 +1,86 @@
+import { Markdown, ModalBase } from '@/components/common';
+import { LetterModalProps } from './LetterModal.types';
+import { ContentSidebar, DataContainer } from '@/components/layout';
+import { Fragment, useEffect, useState } from 'react';
+import Link from 'next/link';
+import EditLetterForm from '@/components/forms/cover-letter/EditLetterForm/EditLetterForm';
+import { WidgetHeader } from '@/components/headers';
+import { RoundButton } from '@/components/buttons';
+import { Cancel, Edit } from '@mui/icons-material';
+
+export default function LetterModal({ letter, updateLetter, onClose }: LetterModalProps) {
+   const [editMode, setEditMode] = useState<boolean>(false);
+   const isOpen = !!letter;
+
+   useEffect(() => {
+      setEditMode(false);
+   }, [letter]);
+
+   if (!isOpen) {
+      return null;
+   }
+
+   return (
+      <ModalBase
+         isOpen={isOpen}
+         onClose={onClose}
+         title="Letter Modal"
+         widthSize="xl"
+      >
+         <WidgetHeader title="Cover Letter Details">
+            {!editMode && <RoundButton
+               title="Edit Letter"
+               color="background-dark"
+               onClick={() => setEditMode(true)}
+            >
+               <Edit />
+            </RoundButton>}
+
+            {editMode && <RoundButton
+               title="Save Changes"
+               color="error"
+               onClick={() => setEditMode(false)}
+            >
+               <Cancel />
+            </RoundButton>}
+         </WidgetHeader>
+
+         {editMode && <EditLetterForm letter={letter} updateLetter={updateLetter} />}
+         {!editMode && <ContentSidebar>
+            <Fragment>
+               <DataContainer vertical>
+                  <label>Subject:</label>
+                  <p>{letter.subject}</p>
+               </DataContainer>
+               <DataContainer vertical>
+                  <label>Subject:</label>
+                  <Markdown value={letter.body} />
+               </DataContainer>
+            </Fragment>
+
+            <Fragment>
+               <DataContainer vertical>
+                  <label>ID:</label>
+                  <p>{letter.id}</p>
+               </DataContainer>
+               <DataContainer vertical>
+                  <label>Company:</label>
+
+                  {!letter.company_id && <p>---</p>}
+                  {letter.company_id && <Link href={`/admin/company/${letter.company_id}`} target="_blank" rel="noopener noreferrer">
+                     {letter.company_name}
+                  </Link>}
+               </DataContainer>
+               <DataContainer vertical>
+                  <label>Opportunity:</label>
+
+                  {!letter.opportunity_id && <p>---</p>}
+                  {letter.opportunity_id && <Link href={`/admin/opportunity/search?opportunity_id=${letter.opportunity_id}`} target="_blank" rel="noopener noreferrer">
+                     {letter.job_title}
+                  </Link>}
+               </DataContainer>
+            </Fragment>
+         </ContentSidebar>}
+      </ModalBase>
+   );
+}

--- a/src/components/modals/LetterModal/LetterModal.tsx
+++ b/src/components/modals/LetterModal/LetterModal.tsx
@@ -53,7 +53,7 @@ export default function LetterModal({ letter, updateLetter, onClose }: LetterMod
                   <p>{letter.subject}</p>
                </DataContainer>
                <DataContainer vertical>
-                  <label>Subject:</label>
+                  <label>Body:</label>
                   <Markdown value={letter.body} />
                </DataContainer>
             </Fragment>

--- a/src/components/modals/LetterModal/LetterModal.types.ts
+++ b/src/components/modals/LetterModal/LetterModal.types.ts
@@ -1,0 +1,7 @@
+import { LetterData } from '@/types/database.types';
+
+export interface LetterModalProps {
+   letter: LetterData | null;
+   onClose: () => void;
+   updateLetter: (id: number, data: Partial<LetterData>) => Promise<LetterData | Error>;
+}

--- a/src/components/modals/OpportunityModal/OpportunityModal.tsx
+++ b/src/components/modals/OpportunityModal/OpportunityModal.tsx
@@ -1,39 +1,34 @@
 import { Card, DateView, FlexLine, Markdown, ModalBase } from '@/components/common';
 import { OpportunityModalProps } from './OpportunityModal.types';
 import { ContentSidebar, DataContainer } from '@/components/layout';
-import { Fragment, useState } from 'react';
+import { Fragment, useEffect, useState } from 'react';
 import { WidgetHeader, OpportunityHeader } from '@/components/headers';
-import { RequestQuote } from '@mui/icons-material';
-import { cvPDFDownloadLink } from '@/helpers/app.helpers';
+import { Download, RequestQuote } from '@mui/icons-material';
+import { cvPDFDownloadLink, letterPDFDownloadLink } from '@/helpers/app.helpers';
 import { Button } from '@mui/material';
 import Link from 'next/link';
 import { allowedLanguages, languageNames } from '@/app.config';
 import styles from './OpportunityModal.module.scss';
-import { CVTile } from '@/components/tiles';
+import { CoverLetterTile, CVTile } from '@/components/tiles';
 import { useRouter } from 'next/navigation';
 import { EditOpportunityForm } from '@/components/forms/opportunities';
-import { LetterData, OpportunityData } from '@/types/database.types';
-import CoverLetterModal from '../CoverLetterModal/CoverLetterModal';
+import BuildCoverLetterModal from '../BuildCoverLetterModal/BuildCoverLetterModal';
+import { RoundButton } from '@/components/buttons';
 
-export default function OpportunityModal({ isOpen, onClose, data, updateData = () => { } }: OpportunityModalProps) {
+export default function OpportunityModal({ isOpen, onClose, data, updateData }: OpportunityModalProps) {
    const [editMode, setEditMode] = useState(false);
    const [coverLetterModal, setCoverLetterModal] = useState(false);
    const router = useRouter();
+
+   useEffect(() => {
+      setEditMode(false);
+   }, [data]);
 
    if (!data) {
       return null;
    }
 
    const isCVExists = data?.relatedCV && data.relatedCV !== null;
-
-   const successUpdate = (newData: OpportunityData) => {
-      setEditMode(false);
-      updateData(newData);
-   }
-
-   const successCoverLetter = (newData: LetterData) => {
-      updateData({ ...data, coverLetter: newData });
-   }
 
    return (
       <ModalBase
@@ -52,7 +47,7 @@ export default function OpportunityModal({ isOpen, onClose, data, updateData = (
          />
 
          <ContentSidebar>
-            {editMode && <EditOpportunityForm opportunity={data} updateData={successUpdate} />}
+            {editMode && <EditOpportunityForm opportunity={data} updateData={updateData} />}
             {!editMode && <Fragment>
                <Card>
                   <DataContainer vertical>
@@ -95,22 +90,30 @@ export default function OpportunityModal({ isOpen, onClose, data, updateData = (
 
             <Fragment>
                <Card>
-                  <WidgetHeader title="Cover Letter" />
+                  <WidgetHeader title="Cover Letter">
+                     {data.coverLetter && <RoundButton
+                        title="Download Cover Letter PDF"
+                        color="background"
+                        LinkComponent={Link}
+                        href={letterPDFDownloadLink(data.coverLetter)}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                     >
+                        <Download />
+                     </RoundButton>}
+                  </WidgetHeader>
 
-                  <h3>{data.coverLetter?.subject || '---'}</h3>
-                  <p>{data.coverLetter?.body || '---'}</p>
-
-                  <Button
+                  {data.coverLetter && <CoverLetterTile letter={data.coverLetter} />}
+                  {!data.coverLetter && <Button
                      fullWidth
                      onClick={() => setCoverLetterModal(true)}
                   >
                      Generate with AI
-                  </Button>
+                  </Button>}
 
-                  <CoverLetterModal
+                  <BuildCoverLetterModal
                      isOpen={coverLetterModal}
                      onClose={() => setCoverLetterModal(false)}
-                     onSuccess={successCoverLetter}
                      opportunityId={data.id}
                      companyId={data.company?.id}
                   />

--- a/src/components/modals/OpportunityModal/OpportunityModal.types.ts
+++ b/src/components/modals/OpportunityModal/OpportunityModal.types.ts
@@ -4,5 +4,5 @@ export interface OpportunityModalProps {
    isOpen: boolean;
    onClose: () => void;
    data: OpportunityData | null;
-   updateData: (newData: OpportunityData) => void;
+   updateData: (id: number, data: Partial<OpportunityData>) => Promise<OpportunityData>;
 }

--- a/src/components/modals/index.tsx
+++ b/src/components/modals/index.tsx
@@ -1,4 +1,5 @@
 export { default as GenerateCustomCVModal } from './GenerateCustomCVModal/GenerateCustomCVModal';
 export { default as LoadingModal } from './LoadingModal/LoadingModal';
 export { default as OpportunityModal } from './OpportunityModal/OpportunityModal';
-export { default as CoverLetterModal } from './CoverLetterModal/CoverLetterModal';
+export { default as BuildCoverLetterModal } from './BuildCoverLetterModal/BuildCoverLetterModal';
+export { default as LetterModal } from './LetterModal/LetterModal';

--- a/src/components/tables/CoverLettersTable/CoverLettersTable.tsx
+++ b/src/components/tables/CoverLettersTable/CoverLettersTable.tsx
@@ -1,9 +1,11 @@
-import { TableBase } from '@/components/common';
-import useConverLetters from '@/hooks/useConverLetters/useConverLetters';
-import { useEffect, useRef } from 'react';
+import { DateView, TableBase } from '@/components/common';
+import LetterModal from '@/components/modals/LetterModal/LetterModal';
+import { useLetters } from '@/hooks';
+import { LetterData } from '@/types/database.types';
+import { Fragment, useEffect, useRef } from 'react';
 
 export default function CoverLettersTable() {
-   const { coverLetters, fetchCoverLetters, loading } = useConverLetters({ query: {} });
+   const { letters, fetchLetters, updateLetter, loading, selectedLetter, setSelectedLetter } = useLetters({ where: { type: 'cover-letter' } });
    const fetched = useRef<boolean>(false);
 
    useEffect(() => {
@@ -12,22 +14,43 @@ export default function CoverLettersTable() {
       }
 
       fetched.current = true;
-      fetchCoverLetters().catch((error) => {
+      fetchLetters().catch((error) => {
          console.error('Error fetching letters:', error);
       });
    }, []);
 
-   return (
-      <TableBase
-         items={coverLetters}
+   useEffect(() => {
+      const searchParams = new URLSearchParams(window.location.search);
+      const letterId = Number(searchParams.get('letter_id'));
+
+      if (!letterId || isNaN(letterId) || !letters.length) {
+         return;
+      }
+      
+      const letter = letters.find(l => l.id === letterId);
+      if (letter) {
+         setSelectedLetter(letter);
+      }
+   }, [letters]);
+
+   const handleRowClick = (letter: LetterData) => {
+      setSelectedLetter(letter);
+   }
+
+   return (<Fragment>
+      <TableBase<LetterData>
+         items={letters}
          loading={loading}
          noDocumentsText="No cover letters found."
+         onClickRow={(item) => handleRowClick(item)}
          columnConfig={[
             { propKey: 'id', label: 'ID' },
             { propKey: 'subject', label: 'Subject' },
-            { propKey: 'from_id', label: 'From ID' },
-            { propKey: 'company_id', label: 'Company ID' }
+            { propKey: 'company_name', label: 'Company Name' },
+            { propKey: 'created_at', label: 'Created At', format: (value) => <DateView date={value as string} type="locale-standard" /> },
          ]}
       />
-   );
+
+      <LetterModal letter={selectedLetter} updateLetter={updateLetter} onClose={() => setSelectedLetter(null)} />
+   </Fragment>);
 }

--- a/src/components/tables/CoverLettersTable/CoverLettersTable.tsx
+++ b/src/components/tables/CoverLettersTable/CoverLettersTable.tsx
@@ -17,7 +17,7 @@ export default function CoverLettersTable() {
       fetchLetters().catch((error) => {
          console.error('Error fetching letters:', error);
       });
-   }, []);
+   }, [fetchLetters]);
 
    useEffect(() => {
       const searchParams = new URLSearchParams(window.location.search);
@@ -31,7 +31,7 @@ export default function CoverLettersTable() {
       if (letter) {
          setSelectedLetter(letter);
       }
-   }, [letters]);
+   }, [letters, setSelectedLetter]);
 
    const handleRowClick = (letter: LetterData) => {
       setSelectedLetter(letter);

--- a/src/components/tables/OpportunitiesTable/OpportunitiesTable.tsx
+++ b/src/components/tables/OpportunitiesTable/OpportunitiesTable.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { TableBase } from '@/components/common';
 import { opportunitiesTableConfig } from './OpportunitiesTable.config';
 import { OpportunityModal } from '@/components/modals';
@@ -19,7 +19,7 @@ export default function OpportunitiesTable({ where, sort, order }: Opportunities
       fetchOpportunities().catch((error) => {
          console.error('Error fetching opportunities:', error);
       });
-   }, [ where, sort, order ]);
+   }, [ where, sort, order, fetchOpportunities ]);
 
    useEffect(() => {
       const searchParams = new URLSearchParams(window.location.search);
@@ -30,7 +30,7 @@ export default function OpportunitiesTable({ where, sort, order }: Opportunities
 
          setSelected(cachedOpportunity || null);
       }
-   }, [ opportunities ]);
+   }, [ opportunities, setSelected ]);
 
    return (
       <>

--- a/src/components/tables/OpportunitiesTable/OpportunitiesTable.tsx
+++ b/src/components/tables/OpportunitiesTable/OpportunitiesTable.tsx
@@ -2,65 +2,52 @@ import React, { useEffect, useRef, useState } from 'react';
 import { TableBase } from '@/components/common';
 import { opportunitiesTableConfig } from './OpportunitiesTable.config';
 import { OpportunityModal } from '@/components/modals';
-import { useAjax } from '@/hooks/useAjax';
 
 // Types
 import type { OpportunitiesTableProps } from './OpportunitiesTable.types';
 import type { OpportunityData } from '@/types/database.types';
+import { useOpportunities } from '@/hooks';
 
 export default function OpportunitiesTable({ where, sort, order }: OpportunitiesTableProps): React.JSX.Element {
-   const [ isLoading, setIsLoading ] = useState<boolean>(true);
-   const [ items, setItems ] = useState<OpportunityData[]>([]);
-   const [ modalData, setModalData ] = useState<OpportunityData | null>(null);
+   const { opportunities, loading, fetchOpportunities, updateOpportunity, selected, setSelected } = useOpportunities({ where, sort, order });
    const isLoaded = useRef<boolean>(false);
-   const ajax = useAjax();
 
    useEffect(() => {
       if (isLoaded.current) return;
-      
+
       isLoaded.current = true;
-      let whereString: string | undefined;
-
-      try {
-         whereString = JSON.stringify(where || {});
-      } catch (error) {
-         console.error('Error stringifying "where" parameter:', error);
-         return;
-      }
-
-      ajax.get<OpportunityData[]>('/opportunity/search', { params: { where: whereString, sort, order } }).then((response) => {
-         if (response.error) {
-            console.error('Error fetching opportunities:', response.message);
-            return;
-         }
-
-         setItems(response.data);
-      }).catch((error) => {
+      fetchOpportunities().catch((error) => {
          console.error('Error fetching opportunities:', error);
-      }).finally(() => {
-         setIsLoading(false);
       });
-   }, [ ajax, where, sort, order ]);
+   }, [ where, sort, order ]);
+
+   useEffect(() => {
+      const searchParams = new URLSearchParams(window.location.search);
+      const opportunityId = Number(searchParams.get('opportunity_id'));
+
+      if (opportunityId && !isNaN(opportunityId)) {
+         const cachedOpportunity = opportunities.find(item => item.id === opportunityId);
+
+         setSelected(cachedOpportunity || null);
+      }
+   }, [ opportunities ]);
 
    return (
       <>
          <TableBase<OpportunityData>
             className="OpportunitiesTable"
-            items={items}
+            items={opportunities}
             columnConfig={opportunitiesTableConfig}
-            loading={isLoading}
+            loading={loading}
             noDocumentsText="No opportunities found"
-            onClickRow={(item) => setModalData(item)}
+            onClickRow={(item) => setSelected(item)}  
          />
 
          <OpportunityModal
-            isOpen={!!modalData}
-            onClose={() => setModalData(null)}
-            data={modalData}
-            updateData={(newData: OpportunityData) => {
-               setItems(prev => prev.map(item => item.id === newData.id ? newData : item));
-               setModalData(newData);
-            }}
+            isOpen={!!selected}
+            onClose={() => setSelected(null)}
+            data={selected}
+            updateData={updateOpportunity}
          />
       </>
    );

--- a/src/components/tiles/CoverLetterTile/CoverLetterTile.module.scss
+++ b/src/components/tiles/CoverLetterTile/CoverLetterTile.module.scss
@@ -1,0 +1,21 @@
+@use '@/style/variables' as *;
+
+.CoverLetterTile {
+   &.MuiButton-root {
+      border-left: 3px solid $warn;
+      background-color: $background-dark;
+      flex-direction: column;
+   
+      label {
+         width: 100%;
+         font-size: 0.8rem;
+         color: $text-soft;
+         text-transform: capitalize;
+      }
+   
+      p {
+         color: $text;
+         text-transform: capitalize;
+      }
+   }
+}

--- a/src/components/tiles/CoverLetterTile/CoverLetterTile.tsx
+++ b/src/components/tiles/CoverLetterTile/CoverLetterTile.tsx
@@ -1,0 +1,23 @@
+import styles from './CoverLetterTile.module.scss';
+import { CoverLetterTileProps } from './CoverLetterTile.types';
+import Button from '@mui/material/Button';
+import Link from 'next/link';
+import { parseCSS } from '@/helpers/parse.helpers';
+
+export default function CoverLetterTile({ letter, className }: CoverLetterTileProps) {
+   const classes = parseCSS(className, [ styles.CoverLetterTile, styles['MuiButton-root'] ]);
+
+   return (
+      <Button
+         className={classes}
+         LinkComponent={Link}
+         href={`/admin/cover-letter/search?letter_id=${letter.id}`}
+         target="_blank"
+         rel="noopener noreferrer"
+         fullWidth
+      >
+         <label>Subject:</label>
+         <p>{letter.subject}</p>
+      </Button>
+   );
+}

--- a/src/components/tiles/CoverLetterTile/CoverLetterTile.types.ts
+++ b/src/components/tiles/CoverLetterTile/CoverLetterTile.types.ts
@@ -1,0 +1,6 @@
+import { LetterData } from '@/types/database.types';
+
+export interface CoverLetterTileProps {
+   className?: string | string[];
+   letter: LetterData;
+}

--- a/src/components/tiles/index.tsx
+++ b/src/components/tiles/index.tsx
@@ -3,3 +3,4 @@ export { default as ErrorTile } from './ErrorTile/ErrorTile';
 export { default as CVTile } from './CVTile/CVTile';
 export { default as LanguageTile } from './LanguageTile/LanguageTile';
 export { default as EducationTile } from './EducationTile/EducationTile';
+export { default as CoverLetterTile } from './CoverLetterTile/CoverLetterTile';

--- a/src/helpers/app.helpers.ts
+++ b/src/helpers/app.helpers.ts
@@ -1,4 +1,4 @@
-import { CVData } from '@/types/database.types';
+import { CVData, LetterData } from '@/types/database.types';
 import { defaultLanguage, languageLevels, languageLevelsPT } from '@/app.config';
 
 export function apiURL(path: string, queryParams?: Record<string, string>): string {
@@ -39,6 +39,10 @@ export function cvPDFDownloadLink(cv?: CVData | null, locale: string = defaultLa
    }
 
    return apiURL(`static/cv/${userFullName}-CV_${cvId}_${locale}.pdf`);
+}
+
+export function letterPDFDownloadLink(letter: LetterData): string {
+   return apiURL(`static/letter/letter-${letter.id}.pdf`);
 }
 
 export function downloadCVPDF(cv: CVData, locale: string): void {

--- a/src/hooks/index.tsx
+++ b/src/hooks/index.tsx
@@ -5,3 +5,6 @@ export { default as FormDatePicker } from './Form/inputs/FormDatePicker';
 export { default as FormMultiSelectChip } from './Form/inputs/FormMultiSelectChip';
 export { default as FormSelect } from './Form/inputs/FormSelect';
 export { default as FormSubmit } from './Form/inputs/FormSubmit';
+
+export { default as useLetters } from './useLetters/useLetters';
+export { default as useOpportunities } from './useOpportinities/useOpportinities';

--- a/src/hooks/useLetters/useLetters.ts
+++ b/src/hooks/useLetters/useLetters.ts
@@ -1,33 +1,38 @@
 import { LetterData } from '@/types/database.types';
 import { useAjax } from '../useAjax';
-import { LetterSearchParams } from './useCoverLetter.types';
+import { LetterSearchParams } from './useLetters.types';
 import { useState } from 'react';
 import { AjaxResponse } from '@/services';
 
-export default function useConverLetters(defaultParams: LetterSearchParams) {
-   const [coverLetters, setCoverLetters] = useState<LetterData[]>([]);
+export default function useLetters(defaultParams: LetterSearchParams = {}) {
+   const [letters, setLetters] = useState<LetterData[]>([]);
    const [loading, setLoading] = useState<boolean>(false);
+   const [selectedLetter, setSelectedLetter] = useState<LetterData | null>(null);
    const ajax = useAjax();
 
-   const fetchCoverLetters = async (params: LetterSearchParams = defaultParams): Promise<LetterData[] | Error> => {
+   const getLetter = (id: number): LetterData | undefined => {
+      return letters.find(letter => letter.id === id);
+   }
+
+   const fetchLetters = async (params: LetterSearchParams = defaultParams): Promise<LetterData[] | Error> => {
       try {
          setLoading(true);
-         const letters = await ajax.get<LetterData[]>('/cover-letter/search', { params });
+         const loaded = await ajax.get<LetterData[]>('/cover-letter/search', { params });
 
-         if (letters.error) {
-            throw new Error(letters.message || 'Failed to fetch cover letters');
+         if (loaded.error) {
+            throw new Error(loaded.message || 'Failed to fetch cover letters');
          }
 
-         if (letters.data && !Array.isArray(letters.data)) {
+         if (loaded.data && !Array.isArray(loaded.data)) {
             throw new Error('Invalid data format received for cover letters');
          }
 
-         if (!letters.data) {
+         if (!loaded.data) {
             return [];
          }
 
-         setCoverLetters(letters.data);
-         return letters.data;
+         setLetters(loaded.data);
+         return loaded.data;
       } catch (error) {
          console.error('Error fetching cover letters:', error);
          throw error;
@@ -36,7 +41,7 @@ export default function useConverLetters(defaultParams: LetterSearchParams) {
       }
    }
 
-   const createCoverLetter = async (data: Partial<LetterData>): Promise<LetterData> => {
+   const createLetter = async (data: Partial<LetterData>): Promise<LetterData> => {
       if (!data) {
          throw new Error('Cover letter data is required for creation');
       }
@@ -58,7 +63,7 @@ export default function useConverLetters(defaultParams: LetterSearchParams) {
       }
    }
 
-   const updateCoverLetter = async (id: number, data: Partial<LetterData>): Promise<LetterData> => {
+   const updateLetter = async (id: number, data: Partial<LetterData>): Promise<LetterData> => {
       if (!id || isNaN(Number(id))) {
          throw new Error('Cover letter ID is required for update');
       }
@@ -71,6 +76,9 @@ export default function useConverLetters(defaultParams: LetterSearchParams) {
             throw new Error(updated.message);
          }
 
+         setLetters(prevLetters => prevLetters.map(letter => letter.id === updated.data.id ? updated.data : letter));
+         setSelectedLetter(updated.data);
+
          return updated.data;
       } catch (error) {
          console.error('Error updating cover letter:', error);
@@ -80,7 +88,7 @@ export default function useConverLetters(defaultParams: LetterSearchParams) {
       }
    }
 
-   const deleteCoverLetter = async (id: number): Promise<AjaxResponse<LetterData>> => {
+   const deleteLetter = async (id: number): Promise<AjaxResponse<LetterData>> => {
       if (!id || isNaN(Number(id))) {
          throw new Error('Cover letter ID is required for deletion');
       }
@@ -88,11 +96,11 @@ export default function useConverLetters(defaultParams: LetterSearchParams) {
       try {
          setLoading(true);
          const deleted = await ajax.delete<LetterData>(`/cover-letter/delete/${id}`);
-   
+
          if (deleted.error) {
             throw new Error(deleted.message);
          }
-   
+
          return deleted;
       } catch (error) {
          console.error('Error deleting cover letter:', error);
@@ -104,10 +112,13 @@ export default function useConverLetters(defaultParams: LetterSearchParams) {
 
    return {
       loading,
-      coverLetters,
-      fetchCoverLetters,
-      createCoverLetter,
-      updateCoverLetter,
-      deleteCoverLetter
+      letters,
+      selectedLetter,
+      getLetter,
+      fetchLetters,
+      createLetter,
+      updateLetter,
+      deleteLetter,
+      setSelectedLetter
    }
 }

--- a/src/hooks/useLetters/useLetters.types.ts
+++ b/src/hooks/useLetters/useLetters.types.ts
@@ -1,5 +1,5 @@
 import { LetterData } from '@/types/database.types';
 
 export interface LetterSearchParams {
-   query: Partial<LetterData>;
+   where?: Partial<LetterData>;
 }

--- a/src/hooks/useOpportinities/useOpportinities.ts
+++ b/src/hooks/useOpportinities/useOpportinities.ts
@@ -1,0 +1,104 @@
+import { OpportunityData } from '@/types/database.types';
+import { useState } from 'react';
+import { OpportunitiesSearchParams, OpportunityCreateParams } from './useOpportunities.types';
+import { useAjax } from '../useAjax';
+import { AjaxResponse } from '@/services';
+
+export default function useOpportunities(defaultParams: OpportunitiesSearchParams = {}) {
+   const [opportunities, setOpportunities] = useState<OpportunityData[]>([]);
+   const [selected, setSelected] = useState<OpportunityData | null>(null);
+   const [loading, setLoading] = useState<boolean>(false);
+   const ajax = useAjax();
+
+   const fetchOpportunities = async (params: OpportunitiesSearchParams = defaultParams): Promise<OpportunityData[]> => {
+      setLoading(true);
+
+      try {
+         const loaded = await ajax.get<OpportunityData[]>('/opportunity/search', { params });
+
+         if (loaded.error) {
+            throw new Error(loaded.message);
+         }
+
+         setOpportunities(loaded.data);
+         return loaded.data;
+      } catch (error) {
+         console.error('Error fetching opportunities:', error);
+         throw error;
+      } finally {
+         setLoading(false);
+      }
+   }
+
+   const createOpportunity = async (data: Partial<OpportunityCreateParams>): Promise<OpportunityData> => {
+      try {
+         const created = await ajax.post<OpportunityData>('/opportunity/create', data);
+
+         if (created.error) {
+            throw new Error(created.message);
+         }
+
+         setOpportunities(prev => [created.data, ...prev]);
+         return created.data;
+      } catch (error) {
+         console.error('Error creating opportunity:', error);
+         throw error;
+      }
+   }
+
+   const updateOpportunity = async (id: number, data: Partial<OpportunityData>): Promise<OpportunityData> => {
+      try {
+         const updated = await ajax.patch<OpportunityData>('/opportunity/update', { id, updates: data });
+
+         if (updated.error) {
+            throw updated;
+         }
+
+         if (updated.data.id === selected?.id) {
+            setSelected(updated.data);
+         }
+
+         setOpportunities(prev => prev.map(item => item.id === updated.data.id ? updated.data : item));
+         return updated.data;
+      } catch (error) {
+         throw error;
+      }
+   }
+
+   const deleteOpportunity = async (id: number): Promise<AjaxResponse | null> => {
+      if (!id) {
+         throw new Error('Invalid opportunity ID');
+      }
+
+      const confirmDelete = confirm('Are you sure you want to delete this opportunity? This action cannot be undone.');
+      if (!confirmDelete) {
+         return null;
+      }
+
+      try {
+         const deleteRelated = confirm('Also delete related data?');
+         const deleted = await ajax.delete<OpportunityData[]>('/opportunity/delete', { data: { id, deleteRelated } });
+
+         if (!deleted.success) {
+            throw new Error('Error deleting opportunity');
+         }
+
+         setOpportunities(prev => prev.filter(item => item.id !== id));
+         return deleted;
+      } catch (error) {
+         console.error('Error deleting opportunity:', error);
+         throw error;
+      }
+   }
+
+   return {
+      opportunities,
+      loading,
+      selected,
+      setSelected,
+      fetchOpportunities,
+      createOpportunity,
+      updateOpportunity,
+      deleteOpportunity,
+   }
+}

--- a/src/hooks/useOpportinities/useOpportinities.ts
+++ b/src/hooks/useOpportinities/useOpportinities.ts
@@ -51,7 +51,7 @@ export default function useOpportunities(defaultParams: OpportunitiesSearchParam
          const updated = await ajax.patch<OpportunityData>('/opportunity/update', { id, updates: data });
 
          if (updated.error) {
-            throw updated;
+            throw new Error(updated.message || 'Failed to update opportunity');
          }
 
          if (updated.data.id === selected?.id) {

--- a/src/hooks/useOpportinities/useOpportunities.types.ts
+++ b/src/hooks/useOpportinities/useOpportunities.types.ts
@@ -1,5 +1,5 @@
 export interface OpportunitiesSearchParams {
-   where?: Record<string, any>;
+   where?: Record<string, unknown>;
    sort?: string;
    order?: 'ASC' | 'DESC';
 }

--- a/src/hooks/useOpportinities/useOpportunities.types.ts
+++ b/src/hooks/useOpportinities/useOpportunities.types.ts
@@ -1,0 +1,17 @@
+export interface OpportunitiesSearchParams {
+   where?: Record<string, any>;
+   sort?: string;
+   order?: 'ASC' | 'DESC';
+}
+
+export interface OpportunityCreateParams {
+   jobURL: string;
+   jobTitle: string;
+   jobDescription: string;
+   jobLocation: string;
+   jobSeniority: string;
+   jobEmploymentType: string;
+   companyName: string;
+   cvSummary: string;
+   cvTemplate: string;
+}

--- a/src/style/variables.scss
+++ b/src/style/variables.scss
@@ -5,6 +5,7 @@ $secondary: #0D1B2A;
 $tertiary: #8FE388;
 
 $success: #4CAF50;
+$warn: #e7b038;
 $error: #e74438;
 $white: #FAFAFA;
 $black: #111;

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -128,8 +128,12 @@ export interface EducationSetData extends BasicData {
 }
 
 export interface LetterData extends BasicData {
+   type: 'cover-letter' | 'email' | 'other';
    subject?: string;
    body: string;
+   from_id: number;
    opportunity_id?: number;
    company_id?: number;
+   company_name?: string;
+   job_title?: string;
 }


### PR DESCRIPTION
## [FRD-193] Description
This pull request introduces several improvements and refactors to forms and modals related to cover letters and opportunities, focusing on better separation of concerns, code reuse, and consistency in data handling. The most significant changes include refactoring form logic to use custom hooks, introducing new modal and form components for editing letters, and updating field names for consistency across the codebase.

**Form and Data Handling Improvements**
* Refactored `BuildCoverLetterForm` and `BuildOpportunityForm` to use `useLetters` and `useOpportunities` hooks for creating letters and opportunities, replacing direct AJAX calls for improved abstraction and maintainability. [[1]](diffhunk://#diff-c5cdc5f3621f9fce1dab32915d95b426a1bb960db9441ed74195e6bac86fe133L1-R12) [[2]](diffhunk://#diff-c5cdc5f3621f9fce1dab32915d95b426a1bb960db9441ed74195e6bac86fe133L21-R23) [[3]](diffhunk://#diff-c6aac60f6d7b7a7c712dc2bbafb769069c9684720c4a112ae3a0319b7a12dff9L1-R24)
* Updated field names in opportunity forms for consistency (`currentInput` → `cvSummary`, `jobCompany` → `companyName`) and ensured summary generation and display use the new names. [[1]](diffhunk://#diff-e30f2f99a9ff865920eddd64857c7ca3404ad32f32dd29e988625b212355d4c2L20-R20) [[2]](diffhunk://#diff-e30f2f99a9ff865920eddd64857c7ca3404ad32f32dd29e988625b212355d4c2L57-R57) [[3]](diffhunk://#diff-e30f2f99a9ff865920eddd64857c7ca3404ad32f32dd29e988625b212355d4c2L90-R90) [[4]](diffhunk://#diff-03723f837d59452c523d2b23cc6eb7abfd5f68e2728fb86056a755f807ab5c31L57-R57)

**New and Enhanced Components**
* Added `EditLetterForm` and its type definition for editing cover letters, and registered it in the forms index for easier reuse. [[1]](diffhunk://#diff-4a87332b6e44b16831465f297db189c15b882cf47813f8e5f5d1ddc8819878dcR1-R68) [[2]](diffhunk://#diff-1ef57c480bcca77a2afcfee946eb5c2ea5d064e83e9a11cc25e6fb9eb79d124aR1-R6) [[3]](diffhunk://#diff-39de82cf6965c79650a5b73f22943c1babb8c7d4328e04aa110bdf35591f34efR8)
* Introduced `LetterModal`, a new modal for viewing and editing letter details, supporting edit mode and displaying related company and opportunity info. [[1]](diffhunk://#diff-68e20c3f080bf12d2328d3cdc2177edf7e5b3601df61576f97ec701b25686902R1-R86) [[2]](diffhunk://#diff-726f901df74065d6eefd1932a6a014323dbdf270f06afc2c35e6ab888fe7b0b4R1-R7)

**Opportunity Management Refactor**
* Updated opportunity editing and header components to use the new hooks (`useOpportunities`) for updating and deleting opportunities, and standardized the edit and delete logic. [[1]](diffhunk://#diff-b63f143c0dec0f2d216fbac516ad23943d764403fca38b731d0415f1d732e648L7-R15) [[2]](diffhunk://#diff-4e9fc6f62f461a5b57f070307e15c236409a12a7ee303f19ff67a958f6389426L5-R5) [[3]](diffhunk://#diff-e9f8847dd4bebb31d032207c446df286a2237e333963011ea0a17d999d542113L6-R22)

**Modal Renaming and API Consistency**
* Renamed `CoverLetterModal` to `BuildCoverLetterModal` and updated related types and props for clearer naming and separation of build/generate vs. edit functionality. (F1b28b14L1, [[1]](diffhunk://#diff-2146da3da8a3b763833538f2c90dce81de9ab013f5226d1f0ccab5e571b36680L21-R21) [[2]](diffhunk://#diff-2146da3da8a3b763833538f2c90dce81de9ab013f5226d1f0ccab5e571b36680L56) [[3]](diffhunk://#diff-e65f9959da0daf48ca791f3b984cba7a183890da704e47a847180eda21f4d635L1-R10)

**Minor UI Enhancement**
* Added `outline: none;` to `.Card` styling for improved visual consistency.

[FRD-193]: https://feliperamosdev.atlassian.net/browse/FRD-193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ