### PR TITLE
[FRD-200] Add useGenLetter hook and refactor cover letter generation

### DIFF
--- a/src/app/admin/opportunity/search/page.tsx
+++ b/src/app/admin/opportunity/search/page.tsx
@@ -14,7 +14,7 @@ export default async function OpportunitySearchPage() {
    url.pathname = '/cover-letter';
 
    return (
-      <SocketProvider config={{ url: url.toString() }}>
+      <SocketProvider config={{ url: url.toString(), autoConnect: false }}>
          <AdminPageBase language={locale}>
             <OpportunitySearch />
          </AdminPageBase>

--- a/src/components/chat/Chat/Chat.script.ts
+++ b/src/components/chat/Chat/Chat.script.ts
@@ -19,7 +19,7 @@ export const handleStartChat = (
    socket: SocketClient | null,
    chatState: boolean,
    emit: SocketEmitEvent,
-   connect: () => Promise<void>,
+   connect: () => Promise<void | SocketClient>,
    dispatch: Dispatch,
    setChatState: () => void,
    setThreadID: (id: string | null) => void,

--- a/src/components/content/admin/opportunity/OpportunityCreate/OpportunityCreate.tsx
+++ b/src/components/content/admin/opportunity/OpportunityCreate/OpportunityCreate.tsx
@@ -3,12 +3,12 @@
 import { Container } from '@/components/common';
 import { BuildOpportunityForm } from '@/components/forms/opportunities';
 import { PageHeader } from '@/components/headers';
-import { useSocket } from '@/services/SocketClient';
+import { useGenLetter } from '@/hooks';
 import { useEffect, useRef, useState } from 'react';
 
 export default function OpportunityCreate() {
    const [connecting, setConnecting] = useState<boolean>(false);
-   const { connect, socket } = useSocket();
+   const { connect } = useGenLetter();
    const attempted = useRef<boolean>(false);
 
    useEffect(() => {
@@ -22,7 +22,7 @@ export default function OpportunityCreate() {
       }).finally(() => {
          setConnecting(false);
       });
-   }, [connect, connecting, socket]);
+   }, [ connecting, connect ]);
 
    return (
       <div className="OpportunityCreate">

--- a/src/components/forms/cover-letter/BuildCoverLetterForm/BuildCoverLetterButtons.tsx
+++ b/src/components/forms/cover-letter/BuildCoverLetterForm/BuildCoverLetterButtons.tsx
@@ -1,0 +1,32 @@
+import { FlexLine } from "@/components/common";
+import { FormSubmit, useGenLetter } from "@/hooks";
+import { useForm } from "@/hooks/Form/Form";
+import { GenerateLetterParams } from "@/hooks/useGenLetter/useGenLetter.types";
+import { Button } from "@mui/material";
+
+export default function BuildCoverLetterButtons({ opportunityId }: Partial<GenerateLetterParams>) {
+   const { values } = useForm();
+   const { generateLetter } = useGenLetter();
+   const { aiThreadID, currentLetter, additionalMessage } = values as Partial<GenerateLetterParams>;
+
+   const regenerateLetter = () => {
+      if (!opportunityId) {
+         console.error('Opportunity ID is required to generate a cover letter.');
+         return;
+      }
+
+      generateLetter({
+         opportunityId,
+         additionalMessage,
+         aiThreadID,
+         currentLetter
+      });
+   }
+
+   return (
+      <FlexLine>
+         <Button title="Generate Cover Letter" onClick={regenerateLetter}>Generate Letter</Button>
+         <FormSubmit label="Save Letter" fullWidth={false} />
+      </FlexLine>
+   );
+}

--- a/src/components/forms/cover-letter/BuildCoverLetterForm/BuildCoverLetterForm.tsx
+++ b/src/components/forms/cover-letter/BuildCoverLetterForm/BuildCoverLetterForm.tsx
@@ -1,8 +1,7 @@
-import { Form, FormInput, FormSubmit, useLetters } from '@/hooks';
+import { Form, FormInput, FormSubmit, useGenLetter, useLetters } from '@/hooks';
 import { BuildCoverLetterFormProps } from './BuildCoverLetterForm.types';
-import { FlexLine } from '@/components/common';
-import { Button } from '@mui/material';
 import { LetterData } from '@/types/database.types';
+import BuildCoverLetterButtons from './BuildCoverLetterButtons';
 
 export default function BuildCoverLetterForm({ initialValues, opportunityId, companyId, onSuccess = () => {} }: BuildCoverLetterFormProps) {
    const { createLetter } = useLetters();
@@ -53,10 +52,7 @@ export default function BuildCoverLetterForm({ initialValues, opportunityId, com
             multiline
          />
 
-         <FlexLine>
-            <Button title="Generate Cover Letter">Generate Letter</Button>
-            <FormSubmit label="Save Letter" fullWidth={false} />
-         </FlexLine>
+         <BuildCoverLetterButtons opportunityId={opportunityId} />
       </Form>
    );
 }

--- a/src/components/forms/cover-letter/BuildCoverLetterForm/BuildCoverLetterForm.tsx
+++ b/src/components/forms/cover-letter/BuildCoverLetterForm/BuildCoverLetterForm.tsx
@@ -1,4 +1,4 @@
-import { Form, FormInput, FormSubmit, useGenLetter, useLetters } from '@/hooks';
+import { Form, FormInput, useLetters } from '@/hooks';
 import { BuildCoverLetterFormProps } from './BuildCoverLetterForm.types';
 import { LetterData } from '@/types/database.types';
 import BuildCoverLetterButtons from './BuildCoverLetterButtons';

--- a/src/components/forms/opportunities/BuildOpportunityForm/components/GenerateSummary.tsx
+++ b/src/components/forms/opportunities/BuildOpportunityForm/components/GenerateSummary.tsx
@@ -5,7 +5,7 @@ import { loadUserCVs } from '@/helpers/database.helpers';
 import { FormInput, FormSelect } from '@/hooks';
 import { useForm } from '@/hooks/Form/Form';
 import { useAjax } from '@/hooks/useAjax';
-import { useSocket } from '@/services/SocketClient';
+import { SocketErrorCallback, useSocket } from '@/services/SocketClient';
 import { useTextResources } from '@/services/TextResources/TextResourcesProvider';
 import { Button } from '@mui/material';
 import { useEffect, useState } from 'react';
@@ -13,7 +13,7 @@ import { useEffect, useState } from 'react';
 export default function GenerateSummary() {
    const { emit, socket, isConnected } = useSocket();
    const { getValue, setFieldValue, setResponseError } = useForm();
-   const [ generateStatus, setGenerateStatus ] = useState<string>();
+   const [generateStatus, setGenerateStatus] = useState<string>();
    const { textResources } = useTextResources();
    const ajax = useAjax();
 
@@ -26,7 +26,7 @@ export default function GenerateSummary() {
       if (!socket || !isConnected) return;
 
       socket.on('opportunities:generate-summary:status', (status) => {
-          switch (status) {
+         switch (status) {
             case 'generating-summary':
                setGenerateStatus('Generating summary');
                break;
@@ -44,7 +44,7 @@ export default function GenerateSummary() {
       const payload = { currentInput, customPrompt, jobDescription, aiThread };
 
       emit('generate-summary', payload, (response) => {
-         const { error, message } = response as { error: boolean; message: string };
+         const { error, message } = response as SocketErrorCallback;
          const { summary, aiThread } = response as { summary: string; aiThread: string };
 
          if (error) {

--- a/src/components/forms/opportunities/BuildOpportunityForm/components/LinkedInScrap.tsx
+++ b/src/components/forms/opportunities/BuildOpportunityForm/components/LinkedInScrap.tsx
@@ -54,7 +54,7 @@ export default function LinkedInScrap() {
 
          setFieldValue('jobURL', jobURL);
          setFieldValue('jobTitle', jobTitle);
-         setFieldValue('companyName', jobCompany);
+         setFieldValue('jobCompany', jobCompany);
          setFieldValue('jobDescription', jobDescription);
          setFieldValue('jobLocation', jobLocation);
          setFieldValue('jobSeniority', jobSeniority);

--- a/src/components/modals/BuildCoverLetterModal/BuildCoverLetterModal.tsx
+++ b/src/components/modals/BuildCoverLetterModal/BuildCoverLetterModal.tsx
@@ -20,11 +20,9 @@ export default function BuildCoverLetterModal({ isOpen = false, onClose, opportu
       }
       
       if (isConnected && isOpen) {
-         generateLetter({ opportunityId }, (response) => {
-
-         });
+         generateLetter({ opportunityId });
       }
-   }, [generateLetter, isConnected, isOpen]);
+   }, [generateLetter, isConnected, isOpen, opportunityId, connect, addStatusListener]);
 
    return (
       <ModalBase

--- a/src/components/modals/BuildCoverLetterModal/BuildCoverLetterModal.tsx
+++ b/src/components/modals/BuildCoverLetterModal/BuildCoverLetterModal.tsx
@@ -1,42 +1,30 @@
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect } from 'react';
 import { ModalBase, Spinner } from '@/components/common';
 import { BuildCoverLetterForm } from '@/components/forms/cover-letter';
-import { BuildCoverLetterModalProps, BuildCoverLetterResponse, GenerateCoverLetterStatus } from './BuildCoverLetterModal.types';
-import { useSocket } from '@/services/SocketClient';
+import { BuildCoverLetterModalProps } from './BuildCoverLetterModal.types';
 import { useTextResources } from '@/services/TextResources/TextResourcesProvider';
 import statusFeedback from '@/resources/text/feedback.text';
-import { LetterData } from '@/types/database.types';
+import { useGenLetter } from '@/hooks';
 
 export default function BuildCoverLetterModal({ isOpen = false, onClose, opportunityId, companyId }: BuildCoverLetterModalProps) {
-   const [ initLetter, setInitLetter ] = useState<Partial<LetterData> | null>(null);
-   const { isConnected, emit } = useSocket();
-   const [ generateStatus, setGenerateStatus ] = useState<GenerateCoverLetterStatus>('starting');
+   const { initLetter, generateStatus, isConnected, setInitLetter, generateLetter, connect, addStatusListener } = useGenLetter();
    const { textResources } = useTextResources(statusFeedback);
 
-   const generateCoverLetter = useCallback(async () => {
-      setInitLetter(null);
-
-      try {
-         emit('generate-letter', { opportunityId }, (response) => {
-            const { letterSubject, letterBody } = response as BuildCoverLetterResponse;
-
-            setGenerateStatus('success');
-            setInitLetter({
-               subject: letterSubject,
-               body: letterBody,
-            });
-         });
-      } catch (error) {
-         console.error('Error generating cover letter:', error);
-         setGenerateStatus('error');
-      }
-   }, [emit, opportunityId]);
-
    useEffect(() => {
-      if (isConnected && isOpen) {
-         generateCoverLetter();
+      if (!isConnected && isOpen) {
+         connect().then(() => {
+            addStatusListener();
+         }).catch(err => {
+            console.error('Socket connection error:', err);
+         });
       }
-   }, [generateCoverLetter, isConnected, isOpen]);
+      
+      if (isConnected && isOpen) {
+         generateLetter({ opportunityId }, (response) => {
+
+         });
+      }
+   }, [generateLetter, isConnected, isOpen]);
 
    return (
       <ModalBase

--- a/src/components/modals/BuildCoverLetterModal/BuildCoverLetterModal.types.ts
+++ b/src/components/modals/BuildCoverLetterModal/BuildCoverLetterModal.types.ts
@@ -1,13 +1,6 @@
-export type GenerateCoverLetterStatus = 'starting' | 'generating' | 'success' | 'error';
-
 export interface BuildCoverLetterModalProps {
    isOpen: boolean;
    onClose: () => void;
    opportunityId: number;
    companyId?: number;
-}
-
-export interface BuildCoverLetterResponse {
-   letterSubject: string;
-   letterBody: string;
 }

--- a/src/hooks/index.tsx
+++ b/src/hooks/index.tsx
@@ -8,3 +8,4 @@ export { default as FormSubmit } from './Form/inputs/FormSubmit';
 
 export { default as useLetters } from './useLetters/useLetters';
 export { default as useOpportunities } from './useOpportinities/useOpportinities';
+export { default as useGenLetter } from './useGenLetter/useGenLetter';

--- a/src/hooks/useGenLetter/useGenLetter.ts
+++ b/src/hooks/useGenLetter/useGenLetter.ts
@@ -1,0 +1,60 @@
+import { SocketErrorCallback, useSocket } from '@/services/SocketClient';
+import { LetterData } from '@/types/database.types';
+import { useCallback, useState } from 'react';
+
+import type {
+   GenerateLetterParams,
+   GenerateLetterResponse,
+   GenerateLetterStatus
+} from './useGenLetter.types';
+
+export default function useGenLetter() {
+   const [ initLetter, setInitLetter ] = useState<Partial<LetterData> | null>(null);
+   const { isConnected, connect, emit, socket } = useSocket();
+   const [ generateStatus, setGenerateStatus ] = useState<GenerateLetterStatus>('starting');
+
+   const generateLetter = useCallback((
+      params: GenerateLetterParams,
+      callback: (response: GenerateLetterResponse) => void = () => {}
+   ) => {
+      setInitLetter(null);
+
+      emit('generate-letter', params, (response) => {
+         const { error, message } = response as SocketErrorCallback;
+         const { letterSubject, letterBody } = response as GenerateLetterResponse;
+
+         if (error) {
+            setGenerateStatus('error');
+            console.error(`Error generating letter: ${message}`);
+            return;
+         }
+
+         setGenerateStatus('success');
+         setInitLetter({
+            subject: letterSubject,
+            body: letterBody,
+         });
+
+         callback({ letterSubject, letterBody });
+      });
+   }, [emit]);
+
+   const addStatusListener = useCallback(() => {
+      if (!socket) return;
+
+      socket.on('letter:generate-letter:status', (status) => {
+         setGenerateStatus(status as GenerateLetterStatus);
+      });
+   }, [socket]);
+
+   return {
+      initLetter,
+      isConnected,
+      generateStatus,
+      connect,
+      generateLetter,
+      setInitLetter,
+      setGenerateStatus,
+      addStatusListener
+   };
+}

--- a/src/hooks/useGenLetter/useGenLetter.types.ts
+++ b/src/hooks/useGenLetter/useGenLetter.types.ts
@@ -1,0 +1,13 @@
+export type GenerateLetterStatus = 'starting' | 'generating' | 'success' | 'error';
+
+export interface GenerateLetterParams {
+   opportunityId: number;
+   aiThreadID?: string;
+   currentLetter?: string;
+   additionalMessage?: string;
+}
+
+export interface GenerateLetterResponse {
+   letterSubject: string;
+   letterBody: string;
+}

--- a/src/services/SocketClient/SocketClient.ts
+++ b/src/services/SocketClient/SocketClient.ts
@@ -55,7 +55,7 @@ export class SocketClient {
    /**
     * Connect to the socket server
     */
-   async connect(): Promise<void> {
+   async connect(): Promise<this | void> {
       if (this.socket?.connected) {
          console.log('[SocketClient] Already connected');
          return;
@@ -85,7 +85,7 @@ export class SocketClient {
                this.stats.lastActivity = new Date();
 
                console.log('[SocketClient] Connected:', this.socket!.id);
-               resolve();
+               resolve(this);
             });
 
             this.socket.on('connect_error', (error) => {

--- a/src/services/SocketClient/SocketClient.types.ts
+++ b/src/services/SocketClient/SocketClient.types.ts
@@ -45,6 +45,8 @@ export interface SocketEventCallback<T = unknown> {
 }
 
 export interface SocketErrorCallback {
+   error: boolean;
+   message: string;
    (error: Error): void;
 }
 
@@ -115,7 +117,7 @@ export interface SocketContextValue {
    socket: SocketClient | null;
    connectionState: SocketConnectionState;
    stats: SocketClientStats;
-   connect: () => Promise<void>;
+   connect: () => Promise<SocketClient | void>;
    disconnect: () => void;
    emit: SocketEmitEvent;
    joinRoom: (roomId: string, password?: string) => void;

--- a/src/services/SocketClient/SocketClient.types.ts
+++ b/src/services/SocketClient/SocketClient.types.ts
@@ -47,7 +47,6 @@ export interface SocketEventCallback<T = unknown> {
 export interface SocketErrorCallback {
    error: boolean;
    message: string;
-   (error: Error): void;
 }
 
 export interface SocketConnectionCallback {

--- a/src/services/SocketClient/SocketProvider.tsx
+++ b/src/services/SocketClient/SocketProvider.tsx
@@ -104,10 +104,11 @@ export function SocketProvider({ children, config = DEFAULT_CONFIG }: SocketProv
       }
    }, [socketConfig]);
 
-   const connect = async () => {
+   const connect = async (): Promise<SocketClient | void> => {
       if (socket) {
          await socket.connect();
          setConnectionState(socket.getConnectionState());
+         return socket;
       }
    };
 


### PR DESCRIPTION
## [FRD-200] Description
This pull request introduces a new `useGenLetter` hook to centralize and simplify cover letter generation logic, refactors several components to use this hook instead of direct socket interactions, and improves the modularity and maintainability of the codebase. It also includes minor bug fixes and type improvements related to socket communication and form handling.

**Cover Letter Generation Refactor:**

- Introduced a new `useGenLetter` hook that encapsulates all logic for generating cover letters, including socket communication, state management, and status handling. This replaces previous ad-hoc usage of the `useSocket` hook throughout the codebase. [[1]](diffhunk://#diff-9967c00e147b430bdb3810e3fcef5be22862373ea07ffb3defaf5d7c6f670d55R1-R60) [[2]](diffhunk://#diff-7bd19ad722b39b7c06adfb827e32a0a67a4ccf833cab9480013b8efe478f608eR1-R13) [[3]](diffhunk://#diff-76789df16f11e405f9d4c49b02e94fed73a8755da5638870f5aaa439a8dd1dd1R11)
- Refactored `BuildCoverLetterModal`, `OpportunityCreate`, and related components to use `useGenLetter` for all cover letter generation actions, improving code clarity and reducing duplication. [[1]](diffhunk://#diff-2146da3da8a3b763833538f2c90dce81de9ab013f5226d1f0ccab5e571b36680L1-R27) [[2]](diffhunk://#diff-adb7e6e467a8e688de5f9785576c0274686ed3c92101eb11a16f294eb0a9b943L6-R11) [[3]](diffhunk://#diff-adb7e6e467a8e688de5f9785576c0274686ed3c92101eb11a16f294eb0a9b943L25-R25)
- Added a new `BuildCoverLetterButtons` component to handle cover letter generation and saving actions, further modularizing form logic. [[1]](diffhunk://#diff-88ae039c87c503ca130dd1da5f92fe0e79ff4523886e8627575efb6dd578a110R1-R32) [[2]](diffhunk://#diff-c5cdc5f3621f9fce1dab32915d95b426a1bb960db9441ed74195e6bac86fe133L1-R4) [[3]](diffhunk://#diff-c5cdc5f3621f9fce1dab32915d95b426a1bb960db9441ed74195e6bac86fe133L56-R55)

**Socket Communication & Typing Improvements:**

- Updated socket-related types and callbacks, including changes to `SocketErrorCallback` and the return type of the `connect` method, to better handle errors and provide more accurate typing throughout the application. [[1]](diffhunk://#diff-22fad32f53f71eed90a0076064d3b4eed3856aa2b6644e03c2bd7bc4a295871bR48-R49) [[2]](diffhunk://#diff-22fad32f53f71eed90a0076064d3b4eed3856aa2b6644e03c2bd7bc4a295871bL118-R120) [[3]](diffhunk://#diff-2cc599465a2c66c0c1071b50a56238fe9cabb994de57d12cc6a8d19eb3006219L58-R58) [[4]](diffhunk://#diff-2cc599465a2c66c0c1071b50a56238fe9cabb994de57d12cc6a8d19eb3006219L88-R88) [[5]](diffhunk://#diff-f3f128b2cfae78bcb50b40b4ffa15333c2c2450232460767c2968ec9afbd787fL107-R111)
- Improved error handling in socket event callbacks, especially for cover letter and summary generation, ensuring more robust user feedback. [[1]](diffhunk://#diff-e30f2f99a9ff865920eddd64857c7ca3404ad32f32dd29e988625b212355d4c2L8-R8) [[2]](diffhunk://#diff-e30f2f99a9ff865920eddd64857c7ca3404ad32f32dd29e988625b212355d4c2L47-R47)

**Form and Data Handling Fixes:**

- Fixed a bug in `LinkedInScrap` where the wrong field name was used when setting the company name, preventing data inconsistencies in job forms.

**Code Cleanup:**

- Removed unused types and response interfaces from `BuildCoverLetterModal.types.ts` that are now handled by the new hook and types.

[FRD-200]: https://feliperamosdev.atlassian.net/browse/FRD-200?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ