### PR TITLE
[FRD-206] Fix small issues after services

### DIFF
--- a/src/components/chat/Chat/Chat.script.ts
+++ b/src/components/chat/Chat/Chat.script.ts
@@ -6,10 +6,10 @@ import type { SocketClient } from '@/services/SocketClient';
 
 export const setBotMessage = (
    dispatch: Dispatch<UnknownAction>,
-   data: { content: string; timestamp: number; messageId?: string }
+   data: { content: string; timestamp: number; messageId?: string; isChunk?: boolean }
 ) => {
-   const { content, timestamp, messageId } = data || {};
-   const message = new Message({ content, timestamp, from: 'assistant', messageId });
+   const { content, timestamp, messageId, isChunk } = data || {};
+   const message = new Message({ content, timestamp, from: 'assistant', messageId, isChunk });
    const serialized = message.serialize();
 
    dispatch(chatSliceActions.setMessage(serialized));
@@ -49,7 +49,7 @@ export const handleStartChat = (
 
          socket.on('message_chunk', (data: unknown) => {
             const { chunk, messageId } = data as { chunk: string; messageId?: string };
-            setBotMessage(dispatch, { content: chunk, timestamp: Date.now(), messageId });
+            setBotMessage(dispatch, { content: chunk, timestamp: Date.now(), messageId, isChunk: true });
          });
 
          socket.on('message_end', (data: unknown) => {

--- a/src/components/forms/cover-letter/BuildCoverLetterForm/BuildCoverLetterButtons.tsx
+++ b/src/components/forms/cover-letter/BuildCoverLetterForm/BuildCoverLetterButtons.tsx
@@ -1,4 +1,5 @@
 import { FlexLine } from '@/components/common';
+import { useChatManager } from '@/contexts/ChatManager/ChatManager';
 import { FormSubmit } from '@/hooks';
 import { useForm } from '@/hooks/Form/Form';
 import { useGenLetterContext } from '@/hooks/useGenLetter/GenLetterContext';
@@ -8,6 +9,7 @@ import { Button } from '@mui/material';
 export default function BuildCoverLetterButtons({ opportunityId }: Partial<GenerateLetterParams>) {
    const { values } = useForm<GenerateLetterParams>();
    const { generateLetter } = useGenLetterContext();
+   const { chat } = useChatManager();
 
    const regenerateLetter = () => {
       if (!opportunityId) {
@@ -17,15 +19,15 @@ export default function BuildCoverLetterButtons({ opportunityId }: Partial<Gener
 
       generateLetter({
          opportunityId,
-         additionalMessage: values.additionalMessage || '',
-         aiThreadID: values.aiThreadID || '',
-         currentLetter: values.body || ''
+         agentId: 'letter-gen',
+         roomId: chat?.roomId || '',
+         prompt: values.prompt || ''
       });
    }
 
    return (
       <FlexLine>
-         <Button title="Generate Cover Letter" onClick={regenerateLetter}>Generate Letter</Button>
+         <Button type="button" title="Generate Cover Letter" onClick={regenerateLetter}>Generate Letter</Button>
          <FormSubmit label="Save Letter" fullWidth={false} />
       </FlexLine>
    );

--- a/src/components/forms/cover-letter/BuildCoverLetterForm/BuildCoverLetterForm.tsx
+++ b/src/components/forms/cover-letter/BuildCoverLetterForm/BuildCoverLetterForm.tsx
@@ -47,7 +47,7 @@ export default function BuildCoverLetterForm({ initialValues, opportunityId, com
          />
 
          <FormInput
-            fieldName="additionalMessage"
+            fieldName="prompt"
             label="Additional Prompt"
             minRows={1}
             multiline

--- a/src/components/forms/opportunities/BuildOpportunityForm/BuildOpportunityForm.module.scss
+++ b/src/components/forms/opportunities/BuildOpportunityForm/BuildOpportunityForm.module.scss
@@ -3,3 +3,10 @@
 .jobScrap {
    text-align: right;
 }
+
+.feedback-section {
+   padding: $padding-m;
+   color: $text-soft;
+   background-color: $background-darken;
+   border-radius: $radius-m;
+}

--- a/src/components/forms/opportunities/BuildOpportunityForm/components/GenerateSummary.tsx
+++ b/src/components/forms/opportunities/BuildOpportunityForm/components/GenerateSummary.tsx
@@ -1,4 +1,4 @@
-import { Card } from '@/components/common';
+import { Card, Markdown } from '@/components/common';
 import { WidgetHeader } from '@/components/headers';
 import { LoadingModal } from '@/components/modals';
 import { useChatManager } from '@/contexts';
@@ -10,6 +10,7 @@ import { SocketErrorCallback, useSocket } from '@/services/SocketClient';
 import { useTextResources } from '@/services/TextResources/TextResourcesProvider';
 import { Button } from '@mui/material';
 import { useEffect, useState } from 'react';
+import styles from '../BuildOpportunityForm.module.scss';
 
 export default function GenerateSummary() {
    const { emit, socket, isConnected } = useSocket();
@@ -21,6 +22,7 @@ export default function GenerateSummary() {
    const roomId = chat?.roomId || '';
 
    const currentInput = getValue('cvSummary');
+   const feedback = getValue('feedback');
    const customPrompt = getValue('customPrompt');
    const jobDescription = getValue('jobDescription');
 
@@ -44,15 +46,15 @@ export default function GenerateSummary() {
 
    const generateSummary = () => {
       const payload = {
+         roomId,
+         agentId: 'summary-gen',
          prompt: customPrompt,
          jobDescription,
-         roomId,
-         agentId: 'summary-gen'
       };
 
       emit('generate-summary', payload, (response) => {
          const { error, message } = response as SocketErrorCallback;
-         const { summary } = response as { summary: string };
+         const { summary, feedback } = response as { summary: string, feedback: string };
 
          if (error) {
             console.error('Error generating CV summary:', message);
@@ -62,6 +64,7 @@ export default function GenerateSummary() {
 
          setFieldValue('customPrompt', '');
          setFieldValue('cvSummary', summary);
+         setFieldValue('feedback', feedback);
       });
    };
 
@@ -90,6 +93,12 @@ export default function GenerateSummary() {
                }
             }}
          />
+
+         {feedback ? (
+            <div className={styles['feedback-section']}>
+               <Markdown value={feedback as string} />
+            </div>
+         ) : null}
 
          {currentInput ? (
             <FormInput

--- a/src/components/modals/BuildCoverLetterModal/BuildCoverLetterModal.tsx
+++ b/src/components/modals/BuildCoverLetterModal/BuildCoverLetterModal.tsx
@@ -26,7 +26,11 @@ export default function BuildCoverLetterModal({ isOpen = false, onClose, opportu
       
       if (isConnected && isOpen && !isGenerated.current && chat?.roomId) {
          isGenerated.current = true;
-         generateLetter({ opportunityId, roomId: chat?.roomId, agentId: 'letter-gen' });
+         generateLetter({
+            opportunityId,
+            roomId: chat?.roomId,
+            agentId: 'letter-gen'
+         });
       }
    }, [isConnected, isOpen, opportunityId, generateLetter, connect, addStatusListener, chat?.roomId]);
 

--- a/src/hooks/useGenLetter/useGenLetter.ts
+++ b/src/hooks/useGenLetter/useGenLetter.ts
@@ -45,7 +45,7 @@ export default function useGenLetter(): GenerateLetterContext {
 
       emit('generate-letter', params, (response) => {
          const { error, message } = response as SocketErrorCallback;
-         const { letterSubject, letterBody } = response as GenerateLetterResponse;
+         const { subject, body } = response as GenerateLetterResponse;
 
          if (error) {
             setGenerateStatus('error');
@@ -55,11 +55,11 @@ export default function useGenLetter(): GenerateLetterContext {
 
          setGenerateStatus('success');
          setInitLetter({
-            subject: letterSubject,
-            body: letterBody,
+            subject,
+            body,
          });
 
-         callback({ letterSubject, letterBody });
+         callback({ subject, body });
       });
    }, [emit]);
 

--- a/src/hooks/useGenLetter/useGenLetter.types.ts
+++ b/src/hooks/useGenLetter/useGenLetter.types.ts
@@ -10,7 +10,7 @@ export interface GenerateLetterParams {
    prompt?: string;
    roomId?: string | null;
    agentId?: string;
-   context?: Record<string, any>;
+   context?: Record<string, unknown>;
 }
 
 export interface GenerateLetterResponse {

--- a/src/hooks/useGenLetter/useGenLetter.types.ts
+++ b/src/hooks/useGenLetter/useGenLetter.types.ts
@@ -1,21 +1,24 @@
 import { SocketClient } from "@/services";
-import { LetterData } from "@/types/database.types";
+import { LetterData, OpportunityData } from "@/types/database.types";
 
 export type GenerateLetterStatus = 'starting' | 'generating' | 'success' | 'error';
 
 export interface GenerateLetterParams {
    opportunityId: number;
-   aiThreadID?: string;
    currentLetter?: string;
    body?: string;
-   additionalMessage?: string;
+   prompt?: string;
    roomId?: string | null;
    agentId?: string;
+   context?: Record<string, any>;
 }
 
 export interface GenerateLetterResponse {
-   letterSubject: string;
-   letterBody: string;
+   subject: string;
+   body: string;
+   success?: boolean;
+   opportunity?: OpportunityData;
+   messageId?: string;
 }
 
 export interface GenerateLetterContext {

--- a/src/models/Message.ts
+++ b/src/models/Message.ts
@@ -5,11 +5,13 @@ type MessageSetup = {
    threadID?: string | null;
    agentId?: string;
    messageId?: string;
+   isChunk?: boolean;
 }
 
 export default class Message {
    public content: string;
    public from: 'user' | 'assistant';
+   public isChunk?: boolean;
    public timestamp?: number;
    public self?: boolean;
    public agentId?: string;
@@ -19,12 +21,13 @@ export default class Message {
    public messageId?: string;
 
    constructor(setup: MessageSetup) {
-      const { timestamp, content, from = 'user', threadID, agentId = '', messageId } = setup;
+      const { timestamp, content, from = 'user', threadID, agentId = '', messageId, isChunk } = setup;
 
       this.threadID = threadID;
       this.messageId = messageId;
       this.agentId = agentId;
       this.self = Boolean(from === 'user');
+      this.isChunk = Boolean(isChunk);
       this.timestamp = timestamp || Date.now();
       this.content = content;
       this.from = from;
@@ -64,7 +67,8 @@ export default class Message {
       return {
          message: this.content,
          roomId: this.threadID,
-         agentId: this.agentId
+         agentId: this.agentId,
+         isChunk: this.isChunk
       };
    }
 }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -35,7 +35,7 @@ const chatSlice = createSlice({
          if (!message.self && chunkindex === -1) {
             // Handle assistant message
             state.history.push(message);
-         } else if (chunkindex > -1) {
+         } else if (chunkindex > -1 && message.isChunk) {
             state.history[chunkindex].content += message.content;
          } else if (state.inputValue) {
             // Handle user message


### PR DESCRIPTION
Add support for streaming assistant message chunks and align generate-letter/summary payloads and responses.

Key changes:
- Messaging: add isChunk to Message model, mark chunked messages in Chat.script, and only append content in store when message.isChunk to support incremental assistant streaming.
- Cover letter UI: rename additionalMessage -> prompt in the form, pass agentId/roomId/prompt when generating letters, and ensure the Generate button is a proper button element; BuildCoverLetterModal adjusted to pass structured params.
- Hooks/types: update useGenLetter to expect subject/body in responses, update types (GenerateLetterParams/GenerateLetterResponse) to include prompt, context, opportunity, messageId and rename response fields.
- Opportunity summary: include roomId/agentId in generate-summary payload, handle feedback from the response, persist it to the form field and render feedback markdown with new .feedback-section styles.

These changes enable streamed assistant responses and unify the generation APIs and payload/response shapes across cover letter and opportunity summary flows.